### PR TITLE
fix: resolve release-please permissions and configuration issues

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   release-please:

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -3,6 +3,8 @@
     ".": {
       "release-type": "go",
       "package-name": "gitlab-auto-mr",
+      "include-component-in-tag": false,
+      "include-v-in-tag": true,
       "changelog-sections": [
         {
           "type": "feat",
@@ -54,5 +56,6 @@
       ]
     }
   },
+  "bootstrap-sha": "bd3695092cdae94c95438d156219e2507e785744",
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
 }


### PR DESCRIPTION
- Add issues write permission to GitHub workflow
- Configure release-please for better commit parsing
- Add bootstrap SHA to handle existing commits
- Set tag format preferences