### PR TITLE
fix: resolve release workflow issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.24"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,8 +60,8 @@ changelog:
 
 release:
   github:
-    owner: "{{ .Env.GITHUB_REPOSITORY_OWNER }}"
-    name: "{{ .ProjectName }}"
+    owner: batonogov
+    name: gitlab-auto-mr
   name_template: "{{ .ProjectName }} {{ .Tag }}"
   draft: false
   prerelease: auto


### PR DESCRIPTION
- Fix GitHub repository owner in GoReleaser config
- Update Go version to 1.24 to match Dockerfile
- Ensure release workflow can properly create binaries and Docker images