### PR TITLE
fix: add packages write permission to docker job in release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -50,6 +50,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This fixes the 'denied: installation not allowed to Write organization package' error when GitHub Actions tries to push Docker images to ghcr.io during the release process.

The docker job in release-please.yml was missing the required 'packages: write' permission to publish container images to GitHub Container Registry.