### PR TITLE
fix: resolve release-please commit parsing issues

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -51,11 +51,9 @@
           "section": "Continuous Integration"
         }
       ],
-      "extra-files": [
-        "README.md"
-      ]
+      "extra-files": ["README.md"]
     }
   },
-  "bootstrap-sha": "bd3695092cdae94c95438d156219e2507e785744",
+  "bootstrap-sha": "9df122bfc33291424e3e00fbaa5c141b2307fac8",
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
 }


### PR DESCRIPTION
- Add bootstrap-sha to skip problematic non-conventional commit
- Set starting point to last successful release (v1.6.1)
- Allow release-please to auto-determine next version from changes
- Fix GitHub Actions workflow failure with commit parsing errors