### PR TITLE
fix: URL-encode branch names and add per_page=1 in getExistingMR (#65, #70)

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"regexp"
 	"strconv"
@@ -448,8 +449,13 @@ func validateMR(sourceBranch, targetBranch string) error {
 }
 
 func getExistingMR(client *http.Client, config *Config) (*MergeRequest, error) {
-	apiURL := fmt.Sprintf("%s/api/v4/projects/%d/merge_requests?state=opened&source_branch=%s&target_branch=%s",
-		config.GitLabURL, config.ProjectID, config.SourceBranch, config.TargetBranch)
+	params := url.Values{}
+	params.Set("state", "opened")
+	params.Set("source_branch", config.SourceBranch)
+	params.Set("target_branch", config.TargetBranch)
+	params.Set("per_page", "1")
+	apiURL := fmt.Sprintf("%s/api/v4/projects/%d/merge_requests?%s",
+		config.GitLabURL, config.ProjectID, params.Encode())
 
 	req, err := http.NewRequest("GET", apiURL, http.NoBody)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -483,6 +483,75 @@ func TestGetExistingMRServerSideFiltering(t *testing.T) {
 	}
 }
 
+func TestGetExistingMRSpecialChars(t *testing.T) {
+	// Branch names containing special chars (+, #, &, spaces) must be URL-encoded
+	// so the server decodes them back to the exact original values, and per_page=1
+	// must be present (issue #65 + #70).
+	const (
+		sourceBranch = "feature/fix-#123 & x+more"
+		targetBranch = "release/v1.0 #2"
+	)
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+
+		query := r.URL.Query()
+
+		// per_page=1 must be requested explicitly
+		if got := query.Get("per_page"); got != "1" {
+			t.Errorf("Expected per_page=1, got %q", got)
+		}
+
+		// Decoded branch values must match the originals exactly
+		if got := query.Get("source_branch"); got != sourceBranch {
+			t.Errorf("Expected source_branch %q, got %q", sourceBranch, got)
+		}
+		if got := query.Get("target_branch"); got != targetBranch {
+			t.Errorf("Expected target_branch %q, got %q", targetBranch, got)
+		}
+
+		mrs := []MergeRequest{
+			{
+				ID:           7,
+				IID:          7,
+				Title:        "Special chars MR",
+				SourceBranch: sourceBranch,
+				TargetBranch: targetBranch,
+				State:        "opened",
+			},
+		}
+		json.NewEncoder(w).Encode(mrs)
+	}))
+	defer server.Close()
+
+	client := &http.Client{}
+	config := &Config{
+		GitLabURL:    server.URL,
+		ProjectID:    123,
+		PrivateToken: "test-token",
+		SourceBranch: sourceBranch,
+		TargetBranch: targetBranch,
+	}
+
+	mr, err := getExistingMR(client, config)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if mr == nil {
+		t.Fatal("Expected to find MR, got nil")
+	}
+	if mr.IID != 7 {
+		t.Errorf("Expected MR IID 7, got %d", mr.IID)
+	}
+	if mr.SourceBranch != sourceBranch {
+		t.Errorf("Expected MR source branch %q, got %q", sourceBranch, mr.SourceBranch)
+	}
+	if requestCount != 1 {
+		t.Errorf("Expected exactly 1 API request, got %d", requestCount)
+	}
+}
+
 func TestGetIssueData(t *testing.T) {
 	// Mock server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

### #65 — branch names not URL-encoded
In `getExistingMR`, branch names were interpolated raw into the query string. Branch names containing `+`, `#`, `&`, or spaces (e.g. `feature/fix-#123`) produced malformed/incorrect URLs. The query is now built with `net/url.Values`, so `source_branch` and `target_branch` are properly encoded.

### #70 — add `per_page=1`
The same call lacked `per_page=1` (GitLab defaults to 20). Since the query returns at most one MR, `per_page=1` is now set explicitly — makes intent clear, reduces payload.

## Test
New `TestGetExistingMRSpecialChars` uses a branch `feature/fix-#123 & x+more` and asserts the server decodes it back to the exact original, and that `per_page=1` is present.

## Checklist
- [x] build / vet / test green
- [x] gofmt clean, lines ≤ 120
- ⚠️ Note: adding `import "net/url"` introduces `importShadow` warnings on 5 pre-existing `url` local vars; these are non-blocking today (CI lint step uses `continue-on-error`) and are fixed in the next PR in the stack (`chore/lint-cleanup`).

Closes #65, Closes #70