### PR TITLE
fix: allow unsetting Squash/RemoveSourceBranch via --update-mr (#66)

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,8 +89,8 @@ type MRUpdateRequest struct {
 	Description        string   `json:"description,omitempty"`
 	AssigneeIDs        []int    `json:"assignee_ids,omitempty"`
 	ReviewerIDs        []int    `json:"reviewer_ids,omitempty"`
-	RemoveSourceBranch bool     `json:"remove_source_branch,omitempty"`
-	Squash             bool     `json:"squash,omitempty"`
+	RemoveSourceBranch *bool    `json:"remove_source_branch,omitempty"`
+	Squash             *bool    `json:"squash,omitempty"`
 	AllowCollaboration bool     `json:"allow_collaboration,omitempty"`
 	MilestoneID        int      `json:"milestone_id,omitempty"`
 	Labels             []string `json:"labels,omitempty"`
@@ -325,8 +325,8 @@ func handleUpdateMR(
 		Description:        description,
 		AssigneeIDs:        config.UserIDs,
 		ReviewerIDs:        config.ReviewerIDs,
-		RemoveSourceBranch: config.RemoveBranch,
-		Squash:             config.SquashCommits,
+		RemoveSourceBranch: boolPtr(config.RemoveBranch),
+		Squash:             boolPtr(config.SquashCommits),
 		AllowCollaboration: config.AllowCollaboration,
 	}
 
@@ -689,6 +689,10 @@ func getEnvInt(key string, defaultValue int) int {
 		}
 	}
 	return defaultValue
+}
+
+func boolPtr(b bool) *bool {
+	return &b
 }
 
 func parseIntSlice(s string) []int {

--- a/main_test.go
+++ b/main_test.go
@@ -188,8 +188,8 @@ func TestMRUpdateRequest(t *testing.T) {
 		Description:        "Updated Description",
 		AssigneeIDs:        []int{123, 456},
 		ReviewerIDs:        []int{789},
-		RemoveSourceBranch: true,
-		Squash:             true,
+		RemoveSourceBranch: boolPtr(true),
+		Squash:             boolPtr(true),
 		AllowCollaboration: false,
 		MilestoneID:        999,
 		Labels:             []string{"bug", "urgent"},
@@ -209,6 +209,53 @@ func TestMRUpdateRequest(t *testing.T) {
 	}
 	if len(updateReq.Labels) != 2 {
 		t.Errorf("Expected 2 labels, got %d", len(updateReq.Labels))
+	}
+
+	// Pointer bool fields must be explicitly serialized, even when false,
+	// so that --update-mr can turn squash / remove-source-branch OFF.
+	// See issue #66: omitempty on bool previously dropped false values.
+	cases := []struct {
+		name     string
+		remove   bool
+		squash   bool
+		wantRm   string
+		wantSq   string
+		wantNull bool
+	}{
+		{name: "true", remove: true, squash: true, wantRm: `"remove_source_branch":true`, wantSq: `"squash":true`},
+		{name: "false", remove: false, squash: false, wantRm: `"remove_source_branch":false`, wantSq: `"squash":false`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := MRUpdateRequest{
+				RemoveSourceBranch: boolPtr(tc.remove),
+				Squash:             boolPtr(tc.squash),
+			}
+			data, err := json.Marshal(req)
+			if err != nil {
+				t.Fatalf("unexpected marshal error: %v", err)
+			}
+			body := string(data)
+			if !strings.Contains(body, tc.wantRm) {
+				t.Errorf("%s: expected JSON to contain %s, got %s", tc.name, tc.wantRm, body)
+			}
+			if !strings.Contains(body, tc.wantSq) {
+				t.Errorf("%s: expected JSON to contain %s, got %s", tc.name, tc.wantSq, body)
+			}
+		})
+	}
+
+	// nil pointer means "don't send" and must be omitted.
+	nilReq := MRUpdateRequest{}
+	nilData, err := json.Marshal(nilReq)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+	if strings.Contains(string(nilData), "remove_source_branch") {
+		t.Errorf("nil pointer should be omitted, got %s", string(nilData))
+	}
+	if strings.Contains(string(nilData), "squash") {
+		t.Errorf("nil pointer should be omitted, got %s", string(nilData))
 	}
 }
 


### PR DESCRIPTION
Switch MRUpdateRequest RemoveSourceBranch and Squash to *bool so an explicit false is serialized (omitempty previously dropped it, making it impossible to turn squash/remove-source-branch OFF via --update-mr). nil still means 'don't send'. Closes #66