### PR TITLE
feat: add --trigger-pipeline to create a merge request pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,29 @@ create_only:
 | `--update-mr`           |       | Update existing MR (required to update, fail if none exists) | `false`                |
 | `--create-only`         |       | Force create new MR (fail if already exists)   | `false`                |
 | `--auto-merge`          |       | Enable merge when pipeline succeeds (auto-merge) | `false`              |
+| `--trigger-pipeline`    |       | Create a merge request pipeline after the MR is created | `false`         |
 | `--insecure`            | `-k`  | Skip SSL certificate verification              | `false`                |
+
+### Merge request pipelines
+
+GitLab does not start a merge request pipeline on its own when the MR is created
+through the API for a commit that already has a branch pipeline. If your CI
+configuration runs jobs only on `merge_request_event`, those jobs never run for
+the newly created MR — and the branch pipeline that did run may look green while
+having executed none of them.
+
+`--trigger-pipeline` asks GitLab for that pipeline explicitly, right after the MR
+is created:
+
+```yaml
+open_merge_request:
+  image: ghcr.io/batonogov/gitlab-auto-mr:latest
+  script:
+    - gitlab_auto_mr --target-branch main --trigger-pipeline
+```
+
+The token needs the `api` scope — a `CI_JOB_TOKEN` cannot create merge requests
+or pipelines for them.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ create_only:
 | `--trigger-pipeline`    |       | Create a merge request pipeline after the MR is created | `false`         |
 | `--insecure`            | `-k`  | Skip SSL certificate verification              | `false`                |
 
-### Merge request pipelines
+### Merge Request Pipelines
 
 GitLab does not start a merge request pipeline on its own when the MR is created
 through the API for a commit that already has a branch pipeline. If your CI
@@ -171,13 +171,22 @@ is created:
 
 ```yaml
 open_merge_request:
-  image: ghcr.io/batonogov/gitlab-auto-mr:latest
+  image: $GITLAB_AUTO_MR_IMAGE
   script:
     - gitlab_auto_mr --target-branch main --trigger-pipeline
 ```
 
-The token needs the `api` scope — a `CI_JOB_TOKEN` cannot create merge requests
-or pipelines for them.
+Two things to expect:
+
+- On the push that creates the MR you will have **two pipelines for the same
+  commit** — the branch pipeline that ran this job, and the merge request
+  pipeline created here. A `workflow` rule such as
+  `$CI_COMMIT_BRANCH && $CI_OPEN_MERGE_REQUESTS == null` keeps later pushes to
+  the same branch down to one.
+- The token needs the `api` scope, and its owner needs at least the Developer
+  role on the project. A `CI_JOB_TOKEN` cannot be used: the Merge Requests API
+  is read-only for job tokens, so it can neither create the MR nor request a
+  pipeline for it.
 
 ## Building
 

--- a/examples/.gitlab-ci.yml
+++ b/examples/.gitlab-ci.yml
@@ -225,3 +225,19 @@ smart_mr_conditional:
       fi
   rules:
     - if: $CI_COMMIT_BRANCH != $TARGET_BRANCH && $CI_PIPELINE_SOURCE == "push"
+
+# MR that gets its checks run: --trigger-pipeline asks GitLab for a merge
+# request pipeline, which it does not create on its own for a commit that
+# already has a branch pipeline. Without it, jobs guarded by
+# `$CI_PIPELINE_SOURCE == "merge_request_event"` never run for the new MR.
+mr_with_pipeline:
+  stage: create-mr
+  image: $GITLAB_AUTO_MR_IMAGE
+  script:
+    - |
+      gitlab_auto_mr \
+        --target-branch $TARGET_BRANCH \
+        --description $MR_DESCRIPTION_FILE \
+        --trigger-pipeline
+  rules:
+    - if: $CI_COMMIT_BRANCH != $TARGET_BRANCH && $CI_PIPELINE_SOURCE == "push"

--- a/main.go
+++ b/main.go
@@ -460,14 +460,30 @@ func triggerMRPipeline(client *http.Client, config *Config, mrIID int) error {
 
 	switch resp.StatusCode {
 	case 200, 201:
+		// The pipeline already exists at this point, so a response we cannot read
+		// is worth a warning but must not fail the run: the body is only used to
+		// tell the user what was created.
 		var pipeline Pipeline
 		if err := json.NewDecoder(resp.Body).Decode(&pipeline); err != nil {
-			return fmt.Errorf("pipeline created but response could not be read: %v", err)
+			fmt.Printf("Warning: merge request pipeline created but response could not be read: %v\n", err)
+			return nil
+		}
+		if pipeline.WebURL != "" {
+			fmt.Printf(
+				"Merge request pipeline created (ID: %d, status: %s): %s\n",
+				pipeline.ID, pipeline.Status, pipeline.WebURL,
+			)
+			return nil
 		}
 		fmt.Printf("Merge request pipeline created (ID: %d, status: %s)\n", pipeline.ID, pipeline.Status)
 		return nil
 	case 401:
 		return fmt.Errorf("unauthorized access, check your access token permissions")
+	case 403:
+		return fmt.Errorf(
+			"forbidden, the token owner needs at least the Developer role on the project " +
+				"to create pipelines",
+		)
 	case 400:
 		respBody, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf(

--- a/main.go
+++ b/main.go
@@ -56,6 +56,7 @@ type Config struct {
 	UpdateMR           bool
 	CreateOnly         bool
 	AutoMerge          bool
+	TriggerPipeline    bool
 }
 
 type Project struct {
@@ -71,6 +72,12 @@ type MergeRequest struct {
 	SourceBranch string `json:"source_branch"`
 	TargetBranch string `json:"target_branch"`
 	State        string `json:"state"`
+}
+
+type Pipeline struct {
+	ID     int    `json:"id"`
+	Status string `json:"status"`
+	WebURL string `json:"web_url"`
 }
 
 type Issue struct {
@@ -164,6 +171,8 @@ func parseFlags() (*Config, error) {
 	flag.BoolVar(&config.UpdateMR, "update-mr", false, "Update existing MR instead of creating new one")
 	flag.BoolVar(&config.CreateOnly, "create-only", false, "Only create new MR, fail if MR already exists")
 	flag.BoolVar(&config.AutoMerge, "auto-merge", false, "Enable merge when pipeline succeeds (auto-merge)")
+	flag.BoolVar(&config.TriggerPipeline, "trigger-pipeline", false,
+		"Create a merge request pipeline after the MR is created")
 	flag.BoolVar(&showVersion, "version", false, "Show version information and exit")
 	flag.BoolVar(&showVersion, "v", false, "Show version information and exit (short)")
 
@@ -296,6 +305,12 @@ func run(config *Config) error {
 		return err
 	}
 
+	if config.TriggerPipeline {
+		if err := triggerMRPipeline(client, config, mrIID); err != nil {
+			return fmt.Errorf("failed to trigger merge request pipeline: %v", err)
+		}
+	}
+
 	if config.AutoMerge {
 		return enableAutoMerge(client, config, mrIID)
 	}
@@ -410,6 +425,60 @@ func enableAutoMerge(client *http.Client, config *Config, mrIID int) error {
 
 	fmt.Printf("Auto-merge enabled for MR (IID: %d)\n", mrIID)
 	return nil
+}
+
+// triggerMRPipeline asks GitLab to create a merge request pipeline for an
+// existing MR.
+//
+// GitLab does not start one on its own when an MR is created through the API
+// for a commit that already has a branch pipeline. A CI configuration whose
+// jobs run only on `merge_request_event` would therefore never see the MR, and
+// the missing checks are easy to mistake for passing ones.
+func triggerMRPipeline(client *http.Client, config *Config, mrIID int) error {
+	if mrIID == 0 {
+		fmt.Println("Warning: could not determine MR IID, skipping pipeline trigger")
+		return nil
+	}
+
+	apiURL := fmt.Sprintf(
+		"%s/api/v4/projects/%d/merge_requests/%d/pipelines",
+		config.GitLabURL, config.ProjectID, mrIID,
+	)
+
+	req, err := http.NewRequest("POST", apiURL, http.NoBody)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("PRIVATE-TOKEN", config.PrivateToken)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case 200, 201:
+		var pipeline Pipeline
+		if err := json.NewDecoder(resp.Body).Decode(&pipeline); err != nil {
+			return fmt.Errorf("pipeline created but response could not be read: %v", err)
+		}
+		fmt.Printf("Merge request pipeline created (ID: %d, status: %s)\n", pipeline.ID, pipeline.Status)
+		return nil
+	case 401:
+		return fmt.Errorf("unauthorized access, check your access token permissions")
+	case 400:
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf(
+			"GitLab refused to create the pipeline, "+
+				"the CI configuration may define no jobs for merge request pipelines: %s",
+			string(respBody),
+		)
+	default:
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
 }
 
 func createHTTPClient(insecure bool) *http.Client {

--- a/main_test.go
+++ b/main_test.go
@@ -1866,6 +1866,7 @@ func TestTriggerMRPipelineErrors(t *testing.T) {
 		wantErr    string
 	}{
 		{"unauthorized", http.StatusUnauthorized, "", "unauthorized access"},
+		{"forbidden", http.StatusForbidden, "", "Developer role"},
 		{"no jobs for MR pipelines", http.StatusBadRequest, `{"message":"No stages / jobs"}`, "refused to create"},
 		{"server error", http.StatusInternalServerError, "boom", "HTTP 500"},
 	}
@@ -1893,5 +1894,116 @@ func TestTriggerMRPipelineErrors(t *testing.T) {
 				t.Errorf("Expected error containing %q, got %v", tt.wantErr, err)
 			}
 		})
+	}
+}
+
+// A response body we cannot parse must not fail the run: GitLab has already
+// created the pipeline, and the body is only used to report what was created.
+func TestTriggerMRPipelineUnreadableBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte("not json"))
+	}))
+	defer server.Close()
+
+	client := &http.Client{}
+	config := &Config{
+		GitLabURL:    server.URL,
+		ProjectID:    123,
+		PrivateToken: "test-token",
+	}
+
+	if err := triggerMRPipeline(client, config, 42); err != nil {
+		t.Errorf("Expected no error for an unreadable body, got %v", err)
+	}
+}
+
+// The pipeline must be requested through run(), and before auto-merge: enabling
+// merge-when-pipeline-succeeds is what the pipeline is needed for.
+func TestRunWithTriggerPipeline(t *testing.T) {
+	var calls []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/api/v4/projects/123") && r.Method == "GET" &&
+			!strings.Contains(r.URL.Path, "merge_requests"):
+			json.NewEncoder(w).Encode(Project{ID: 123, Name: "test-project", DefaultBranch: "main"})
+		case strings.HasPrefix(r.URL.Path, "/api/v4/projects/123/merge_requests") && r.Method == "GET":
+			json.NewEncoder(w).Encode([]MergeRequest{})
+		case strings.HasSuffix(r.URL.Path, "/merge_requests") && r.Method == "POST":
+			calls = append(calls, "create")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(MergeRequest{ID: 1, IID: 10, Title: "Test MR"})
+		case strings.HasSuffix(r.URL.Path, "/merge_requests/10/pipelines") && r.Method == "POST":
+			calls = append(calls, "pipeline")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(Pipeline{ID: 7, Status: "created"})
+		case strings.HasSuffix(r.URL.Path, "/merge_requests/10/merge") && r.Method == "PUT":
+			calls = append(calls, "merge")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(MergeRequest{ID: 1, IID: 10})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	config := &Config{
+		GitLabURL:       server.URL,
+		ProjectID:       123,
+		PrivateToken:    "test-token",
+		SourceBranch:    "feature/test",
+		TargetBranch:    "main",
+		UserIDs:         []int{1},
+		TriggerPipeline: true,
+		AutoMerge:       true,
+	}
+
+	if err := run(config); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	want := []string{"create", "pipeline", "merge"}
+	if len(calls) != len(want) {
+		t.Fatalf("Expected calls %v, got %v", want, calls)
+	}
+	for i := range want {
+		if calls[i] != want[i] {
+			t.Fatalf("Expected calls %v, got %v", want, calls)
+		}
+	}
+}
+
+// Without the flag nothing extra is requested — the default behavior is unchanged.
+func TestRunWithoutTriggerPipeline(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/pipelines") && r.Method == "POST":
+			t.Error("Expected no pipeline request without --trigger-pipeline")
+		case strings.HasPrefix(r.URL.Path, "/api/v4/projects/123") && r.Method == "GET" &&
+			!strings.Contains(r.URL.Path, "merge_requests"):
+			json.NewEncoder(w).Encode(Project{ID: 123, Name: "test-project", DefaultBranch: "main"})
+		case strings.HasPrefix(r.URL.Path, "/api/v4/projects/123/merge_requests") && r.Method == "GET":
+			json.NewEncoder(w).Encode([]MergeRequest{})
+		case strings.HasSuffix(r.URL.Path, "/merge_requests") && r.Method == "POST":
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(MergeRequest{ID: 1, IID: 10, Title: "Test MR"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	config := &Config{
+		GitLabURL:    server.URL,
+		ProjectID:    123,
+		PrivateToken: "test-token",
+		SourceBranch: "feature/test",
+		TargetBranch: "main",
+		UserIDs:      []int{1},
+	}
+
+	if err := run(config); err != nil {
+		t.Errorf("Expected no error, got %v", err)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1809,3 +1809,89 @@ func TestParseFlags(t *testing.T) {
 		})
 	}
 }
+
+func TestTriggerMRPipeline(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("Expected POST method, got %s", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/merge_requests/42/pipelines") {
+			t.Errorf("Expected path ending with /merge_requests/42/pipelines, got %s", r.URL.Path)
+		}
+		if r.Header.Get("PRIVATE-TOKEN") != "test-token" {
+			t.Errorf("Expected PRIVATE-TOKEN header, got %s", r.Header.Get("PRIVATE-TOKEN"))
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(Pipeline{ID: 7, Status: "created", WebURL: "https://gitlab.example.com/p/7"})
+	}))
+	defer server.Close()
+
+	client := &http.Client{}
+	config := &Config{
+		GitLabURL:    server.URL,
+		ProjectID:    123,
+		PrivateToken: "test-token",
+	}
+
+	if err := triggerMRPipeline(client, config, 42); err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+}
+
+// A missing IID must not fail the run: the MR itself has already been created.
+func TestTriggerMRPipelineZeroIID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("Expected no request when MR IID is unknown")
+	}))
+	defer server.Close()
+
+	client := &http.Client{}
+	config := &Config{
+		GitLabURL:    server.URL,
+		ProjectID:    123,
+		PrivateToken: "test-token",
+	}
+
+	if err := triggerMRPipeline(client, config, 0); err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+}
+
+func TestTriggerMRPipelineErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantErr    string
+	}{
+		{"unauthorized", http.StatusUnauthorized, "", "unauthorized access"},
+		{"no jobs for MR pipelines", http.StatusBadRequest, `{"message":"No stages / jobs"}`, "refused to create"},
+		{"server error", http.StatusInternalServerError, "boom", "HTTP 500"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			client := &http.Client{}
+			config := &Config{
+				GitLabURL:    server.URL,
+				ProjectID:    123,
+				PrivateToken: "test-token",
+			}
+
+			err := triggerMRPipeline(client, config, 42)
+			if err == nil {
+				t.Fatal("Expected an error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("Expected error containing %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

GitLab does not start a merge request pipeline on its own when the MR is created through the API for a commit that already has a branch pipeline.

A CI configuration whose jobs run only on `merge_request_event` therefore never runs them for the newly created MR. Worse, the branch pipeline that *did* run can look green while having executed none of those jobs — so the MR appears checked when nothing checked it. The usual workaround is pushing an empty commit to force a real MR pipeline.

## Change

New `--trigger-pipeline` flag: after the MR is created, ask GitLab for that pipeline explicitly via `POST /projects/:id/merge_requests/:iid/pipelines`.

- Off by default — existing behaviour is unchanged.
- Runs **before** `--auto-merge`. Auto-merge waits for a pipeline, so it benefits from one existing; this also addresses the `405 the pipeline may not have started yet` case already handled in `acceptMR`.
- An unknown MR IID is not a failure: the MR itself has been created, so the tool warns and skips, mirroring `enableAutoMerge`.
- `400` gets its own message, since the common cause is a CI config that defines no jobs for merge request pipelines.

Note that `CI_JOB_TOKEN` cannot be used here — the Merge Requests API is read-only for job tokens, so the `api` scope of a personal or project access token is still required, exactly as for creating the MR.

## Tests

Three tests in the style of the neighbouring ones, using `httptest`:

- successful creation — asserts method, path and `PRIVATE-TOKEN` header;
- `mrIID = 0` — the mock server fails the test if any request arrives;
- table-driven error cases for 401, 400 and 500.

`gofmt`, `go vet`, `golangci-lint` (0 issues) and `go test ./...` all pass locally.