### PR TITLE
docs: document token ownership and fix stale CLAUDE.md notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Single-file application (`main.go`) with all logic:
 
 - **Config** struct holds all CLI flags parsed by `parseFlags()`
 - **run()** is the main orchestrator: get project → validate → check existing MR → create/update MR → optionally enable auto-merge
-- API functions (`getProject`, `getExistingMR`, `createMR`, `updateMR`, `acceptMR`) each handle one GitLab API endpoint
+- API functions (`getProject`, `getExistingMR`, `getIssueData`, `createMR`, `updateMR`, `acceptMR`) each handle one GitLab API endpoint
 - All HTTP calls use `*http.Client` and `*Config` as parameters for testability
 
 Tests (`main_test.go`) use `httptest.NewServer` to mock the GitLab API. Integration tests go through `run()` with a mock server.
@@ -47,5 +47,6 @@ Tests (`main_test.go`) use `httptest.NewServer` to mock the GitLab API. Integrat
 
 - `createMR` returns `(*MergeRequest, error)` — the returned MR is needed for auto-merge IID
 - Error messages from API functions include HTTP status and response body
-- `parseFlags()` calls `os.Exit(1)` on validation errors — not testable via `run()`
+- `parseFlags()` returns an `error` for every validation failure, so validation is testable directly; `os.Exit` lives only in `main()`
+- `parseFlags()` returns the sentinel `errShowVersion` after `--version` printed the version — `main()` treats it as a clean exit (status 0)
 - The `--update-mr` flag is required to update an existing MR; without it, the tool just informs and exits

--- a/README.md
+++ b/README.md
@@ -188,6 +188,28 @@ Two things to expect:
   is read-only for job tokens, so it can neither create the MR nor request a
   pipeline for it.
 
+## Operating
+
+The tool acts on behalf of whoever owns `GITLAB_PRIVATE_TOKEN`. That dependency is
+easy to lose track of: merge requests start appearing "by themselves", and months
+later nobody remembers that behind them stands a live account holding an
+`api`-scoped token.
+
+- **Use a service account, not a person.** A personal token disappears when that
+  person leaves the company or rotates their credentials, and every MR the tool
+  opens is attributed to them.
+- **Give the account Developer on the project — no more.** That is enough to read
+  the project and to create, update and merge merge requests.
+- **`CI_JOB_TOKEN` cannot be substituted.** The Merge Requests API is read-only for
+  job tokens, so a personal or project access token with the `api` scope is
+  required.
+- **Plan for rotation.** GitLab no longer issues non-expiring personal access
+  tokens, so expiry is scheduled work. When the token expires, MR creation simply
+  stops — and "no new MRs" is a symptom that is easy to miss for weeks.
+- **Name the account so its purpose is obvious** (for example
+  `svc-gitlab-auto-mr`). Whoever finds it during a directory cleanup will decide
+  its fate based on the name alone; an account called `test1` gets deleted.
+
 ## Building
 
 ### Prerequisites
@@ -306,6 +328,8 @@ Error: unable to get project 12345: unauthorized access, check your access token
 ```
 
 - Check your `GITLAB_PRIVATE_TOKEN` is valid and has `api` scope
+- An expired or revoked token gives the same message — see [Operating](#operating)
+  for who the token should belong to and why rotation is scheduled work
 
 **MR Already Exists**
 


### PR DESCRIPTION
Closes #149, closes #147.

## README — new `Operating` section

The README explained that the token needs the `api` scope but said nothing about *whose* token it should be or what happens to it over time. The new section states plainly:

- the token belongs to a **service account, not a person** — otherwise every MR is attributed to whoever created it, and the tool breaks when they leave;
- that account needs **Developer** on the project, no more;
- `CI_JOB_TOKEN` is **not** a substitute — the Merge Requests API is read-only for job tokens;
- **rotation is scheduled work** — GitLab no longer issues non-expiring PATs, and the symptom of expiry ("no new MRs") is easy to miss for weeks;
- **name the account so its purpose is obvious** — whoever finds it later decides its fate from the name alone.

The Troubleshooting entry for the authentication error now points at that section, since an expired token produces exactly the same message as an invalid one.

## CLAUDE.md — two stale claims

- `parseFlags()` calls `os.Exit(1)` on validation errors — not testable via `run()`

Untrue since da235f3: `parseFlags` returns an `error` for every validation failure and `os.Exit` appears only in `main()`. The line mattered because this file briefs agents — anything reading it would skip tests that are now straightforward. Replaced with the accurate behaviour, plus a note on the `errShowVersion` sentinel.

- The API-function list was missing `getIssueData`.

`triggerMRPipeline` is deliberately left out — it lands with #143.

## Verification

Docs only; no code touched. `go build ./... && go vet ./... && go test ./...` still green.