### PR TITLE
chore(docker): drop redundant chmod and run as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,15 +24,17 @@ FROM alpine:3.24.1
 
 RUN apk --no-cache --no-scripts add ca-certificates
 
+# Run as a non-root user; the tool only needs to make outbound HTTPS calls
+RUN adduser -D -H -u 10001 app
+
 WORKDIR /app
 
-# Copy the binary from builder stage
+# Copy the binary from builder stage (COPY --from preserves the executable bit)
 COPY --from=builder /app/gitlab_auto_mr .
-
-# Make it executable
-RUN chmod +x ./gitlab_auto_mr
 
 # Add to PATH
 ENV PATH="/app:${PATH}"
+
+USER app
 
 CMD ["./gitlab_auto_mr"]


### PR DESCRIPTION
Closes #148. Two small Dockerfile cleanups, swept together.

**`chmod` removed.** `COPY --from` preserves the executable bit from the builder stage, so `RUN chmod +x ./gitlab_auto_mr` only added a layer.

**Non-root user.** The final image ran as root. Not dramatic for a CI tool — the runner controls the environment — but one `adduser` line clears the corresponding hadolint/Trivy findings for anyone scanning the image. The user is created with `-D -H` (no password, no home) and a fixed uid `10001` so the identity is stable across rebuilds; the tool only makes outbound HTTPS calls and needs nothing else.

## Verification

Built the image locally and ran it:

```
$ docker run --rm glmr-test sh -c 'id; ls -l /app/gitlab_auto_mr; ./gitlab_auto_mr --version'
uid=10001(app) gid=10001(app) groups=10001(app)
-rwxr-xr-x    1 root     root       5963938 Aug 21 09:25 /app/gitlab_auto_mr
gitlab-auto-mr dev (commit: none, built: unknown)
```

The executable bit survives without the `chmod`, and the binary runs fine as a non-owner (`0755`).

One behaviour change worth naming: a description file mounted with `--description` must now be readable by uid `10001`. World-readable mounts (the usual case) are unaffected.