### PR TITLE
ci: make golangci-lint and gosec blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,6 @@ jobs:
         with:
           version: latest
           args: --verbose
-        continue-on-error: true
 
   build:
     name: Build
@@ -126,21 +125,13 @@ jobs:
           go-version: "1.25"
 
       - name: Install gosec
-        run: go install github.com/securecodewarrior/gosec/v2/cmd/gosec@latest
-        continue-on-error: true
+        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.28.0
 
       - name: Run Gosec Security Scanner
-        run: |
-          if command -v gosec >/dev/null 2>&1; then
-            gosec -fmt sarif -out gosec.sarif ./...
-          else
-            echo "gosec not available, skipping security scan"
-            echo '{"version": "2.1.0", "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json", "runs": [{"tool": {"driver": {"name": "gosec", "version": "1.0.0"}}, "results": []}]}' > gosec.sarif
-          fi
-        continue-on-error: true
+        run: gosec -fmt sarif -out gosec.sarif -stdout -verbose text ./...
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: gosec.sarif
-        if: always()
+        if: always() && hashFiles('gosec.sarif') != ''

--- a/main.go
+++ b/main.go
@@ -503,8 +503,10 @@ func createHTTPClient(insecure bool) *http.Client {
 	}
 
 	if insecure {
+		// #nosec G402 -- certificate verification is disabled only at the user's
+		// explicit request, via --insecure/-k.
 		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // user-requested via --insecure flag
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}
 		client.Transport = tr
 	}
@@ -609,6 +611,8 @@ func getDescriptionData(descriptionPath string) string {
 		return ""
 	}
 
+	// #nosec G304 -- the path comes from the caller's own --description flag and the
+	// tool runs with the caller's rights, so there is no privilege boundary to cross.
 	data, err := os.ReadFile(descriptionPath)
 	if err != nil {
 		fmt.Printf("Unable to read description file at %s: %v. No description will be set.\n",


### PR DESCRIPTION
Closes #79.

## The scanner was never running

The issue asked to drop `continue-on-error`. Looking at the job, that was the smaller half of the problem:

```yaml
- name: Install gosec
  run: go install github.com/securecodewarrior/gosec/v2/cmd/gosec@latest
  continue-on-error: true

- name: Run Gosec Security Scanner
  run: |
    if command -v gosec >/dev/null 2>&1; then
      gosec -fmt sarif -out gosec.sarif ./...
    else
      echo "gosec not available, skipping security scan"
      echo '{... "results": []}' > gosec.sarif
    fi
  continue-on-error: true
```

`github.com/securecodewarrior/gosec/v2` is not a real module path — the project lives at `github.com/securego/gosec/v2`. The install failed, `continue-on-error` swallowed it, the fallback branch wrote a SARIF file with an empty `results` array, and that empty file was uploaded to code scanning. Every PR got a green, authoritative-looking "no security findings" that came from a hardcoded JSON literal.

Fixed by installing from the correct path, pinned to `v2.28.0` (the repo SHA-pins its actions; `@latest` in a blocking security step is the same class of surprise), and deleting the fallback so an install failure is loud.

## The two findings it surfaces

Running gosec v2.28.0 against `main` locally gives exactly two, both known-safe and now annotated in `main.go`:

- **G402** — `InsecureSkipVerify: true`, which is what `--insecure/-k` exists to do.
- **G304** — `os.ReadFile(descriptionPath)`, where the path is the caller's own `--description` value and the tool runs with the caller's rights.

Worth noting: the G402 line already carried `//nolint:gosec`, but **gosec does not honour `nolint` directives** — only its own `#nosec`. So that comment was suppressing nothing in the standalone scanner. Both annotations are now `#nosec <rule> -- <reason>`.

## golangci-lint

`golangci-lint run` reports `0 issues` on `main`, so its `continue-on-error` is removed too — no code changes needed for that half.

## Verification

```
$ gosec -quiet ./...        # exit 0, Nosec: 2
$ golangci-lint run
0 issues.
$ go test ./...
ok  	gitlab-auto-mr	1.218s
```

The SARIF upload keeps `if: always()` so findings still reach code scanning when the scan fails, guarded by `hashFiles('gosec.sarif') != ''` so a failed install surfaces as the install error rather than a confusing upload error.