### PR TITLE
feat: support GITLAB_AUTO_MR_TARGET_BRANCH

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,11 +138,16 @@ create_only:
 - `CI_PROJECT_URL` - GitLab URL
 - `CI_COMMIT_REF_NAME` - Source branch name
 
+### Optional Environment Variables
+
+- `GITLAB_AUTO_MR_TARGET_BRANCH` - Target branch for the MR. Overridden by
+  `--target-branch`/`-t`; when neither is set, the project's default branch is used.
+
 ### CLI Options
 
 | Option                  | Short | Description                                    | Default                |
 | ----------------------- | ----- | ---------------------------------------------- | ---------------------- |
-| `--target-branch`       | `-t`  | Target branch for MR                           | Project default branch |
+| `--target-branch`       | `-t`  | Target branch for MR (`GITLAB_AUTO_MR_TARGET_BRANCH`) | Project default branch |
 | `--commit-prefix`       | `-c`  | MR title prefix                                | `Draft`                |
 | `--title`               |       | Custom MR title                                | Source branch name     |
 | `--description`         | `-d`  | Path to description file                       | -                      |

--- a/main.go
+++ b/main.go
@@ -152,8 +152,11 @@ func parseFlags() (*Config, error) {
 	flag.StringVar(&reviewerIDsStr, "reviewer-id", "", "Reviewer IDs (comma-separated)")
 	flag.BoolVar(&config.Insecure, "insecure", false, "Skip SSL verification")
 	flag.BoolVar(&config.Insecure, "k", false, "Skip SSL verification (short)")
-	flag.StringVar(&config.TargetBranch, "target-branch", "", "Target branch to merge onto")
-	flag.StringVar(&config.TargetBranch, "t", "", "Target branch to merge onto (short)")
+	// Both spellings share one variable, so they must share one default: whichever
+	// flag.StringVar runs last decides the initial value.
+	targetBranchDefault := getEnv("GITLAB_AUTO_MR_TARGET_BRANCH", "")
+	flag.StringVar(&config.TargetBranch, "target-branch", targetBranchDefault, "Target branch to merge onto")
+	flag.StringVar(&config.TargetBranch, "t", targetBranchDefault, "Target branch to merge onto (short)")
 	flag.StringVar(&config.CommitPrefix, "commit-prefix", "Draft", "Prefix for MR title")
 	flag.StringVar(&config.CommitPrefix, "c", "Draft", "Prefix for MR title (short)")
 	flag.BoolVar(&config.RemoveBranch, "remove-branch", false, "Remove source branch after merge")

--- a/main_test.go
+++ b/main_test.go
@@ -1627,6 +1627,7 @@ func clearRequiredParseEnv(t *testing.T) {
 		"CI_PROJECT_ID",
 		"CI_PROJECT_URL",
 		"GITLAB_USER_ID",
+		"GITLAB_AUTO_MR_TARGET_BRANCH",
 	} {
 		t.Setenv(key, "")
 	}
@@ -1742,6 +1743,62 @@ func TestParseFlags(t *testing.T) {
 			setup:    setRequiredParseEnv,
 			wantErr:  true,
 			sentinel: true,
+		},
+		{
+			name: "target-branch-from-env",
+			args: []string{"prog"},
+			setup: func(t *testing.T) {
+				setRequiredParseEnv(t)
+				t.Setenv("GITLAB_AUTO_MR_TARGET_BRANCH", "develop")
+			},
+			checkConfig: func(t *testing.T, c *Config) {
+				t.Helper()
+				if c.TargetBranch != "develop" {
+					t.Errorf("TargetBranch = %q, want %q", c.TargetBranch, "develop")
+				}
+			},
+		},
+		{
+			name: "target-branch-flag-overrides-env",
+			args: []string{"prog", "--target-branch", "release/1.x"},
+			setup: func(t *testing.T) {
+				setRequiredParseEnv(t)
+				t.Setenv("GITLAB_AUTO_MR_TARGET_BRANCH", "develop")
+			},
+			checkConfig: func(t *testing.T, c *Config) {
+				t.Helper()
+				if c.TargetBranch != "release/1.x" {
+					t.Errorf("TargetBranch = %q, want %q", c.TargetBranch, "release/1.x")
+				}
+			},
+		},
+		{
+			name: "target-branch-short-flag-overrides-env",
+			args: []string{"prog", "-t", "release/1.x"},
+			setup: func(t *testing.T) {
+				setRequiredParseEnv(t)
+				t.Setenv("GITLAB_AUTO_MR_TARGET_BRANCH", "develop")
+			},
+			checkConfig: func(t *testing.T, c *Config) {
+				t.Helper()
+				if c.TargetBranch != "release/1.x" {
+					t.Errorf("TargetBranch = %q, want %q", c.TargetBranch, "release/1.x")
+				}
+			},
+		},
+		{
+			name: "target-branch-unset-falls-through-to-project-default",
+			args: []string{"prog"},
+			setup: func(t *testing.T) {
+				setRequiredParseEnv(t)
+			},
+			checkConfig: func(t *testing.T, c *Config) {
+				t.Helper()
+				// run() substitutes the project's default branch when this is empty.
+				if c.TargetBranch != "" {
+					t.Errorf("TargetBranch = %q, want empty", c.TargetBranch)
+				}
+			},
 		},
 		{
 			name:  "success",


### PR DESCRIPTION
Closes #78.

Adds `GITLAB_AUTO_MR_TARGET_BRANCH`, so the target branch can be set per environment without editing the command line. Precedence, as the issue asked:

1. `--target-branch` / `-t`
2. `GITLAB_AUTO_MR_TARGET_BRANCH`
3. the project's default branch

Steps 1–2 happen in `parseFlags`; step 3 is the existing fallback in `run()`, which fills in `project.DefaultBranch` when `TargetBranch` is still empty. Nothing changes for users who set neither.

## One subtlety

`--target-branch` and `-t` bind the same `Config` field, so both `flag.StringVar` calls must be given the env-derived default — the last registration decides the initial value, and giving only the long form the default would leave it silently reset to `""`. The code carries a comment saying so, and there is a subtest for each spelling.

## Tests

Four subtests in `TestParseFlags`: value from env; long flag beating env; short flag beating env; and neither set, asserting the field stays empty so `run()`'s project-default path is still reached. `GITLAB_AUTO_MR_TARGET_BRANCH` was added to `clearRequiredParseEnv` so it cannot leak into the other subtests.

```
$ go test ./...
ok  	gitlab-auto-mr
$ golangci-lint run
0 issues.
```