### PR TITLE
feat: add --label and --milestone flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ create_only:
 
 - `GITLAB_AUTO_MR_TARGET_BRANCH` - Target branch for the MR. Overridden by
   `--target-branch`/`-t`; when neither is set, the project's default branch is used.
+- `GITLAB_AUTO_MR_LABELS` - Labels for the MR (comma-separated). Overridden by `--label`.
+- `GITLAB_AUTO_MR_MILESTONE` - Milestone ID for the MR. Overridden by `--milestone`.
 
 ### CLI Options
 
@@ -153,6 +155,8 @@ create_only:
 | `--description`         | `-d`  | Path to description file                       | -                      |
 | `--remove-branch`       | `-r`  | Delete source branch after merge               | `false`                |
 | `--squash-commits`      | `-s`  | Squash commits on merge                        | `false`                |
+| `--label`               |       | Labels for the MR, comma-separated (`GITLAB_AUTO_MR_LABELS`) | -         |
+| `--milestone`           |       | Milestone ID for the MR (`GITLAB_AUTO_MR_MILESTONE`) | -                  |
 | `--use-issue-name`      | `-i`  | Use issue data from branch name                | `false`                |
 | `--allow-collaboration` | `-a`  | Allow commits from merge target members        | `false`                |
 | `--reviewer-id`         |       | Reviewer user ID(s) (comma-separated)          | -                      |
@@ -192,28 +196,6 @@ Two things to expect:
   role on the project. A `CI_JOB_TOKEN` cannot be used: the Merge Requests API
   is read-only for job tokens, so it can neither create the MR nor request a
   pipeline for it.
-
-## Operating
-
-The tool acts on behalf of whoever owns `GITLAB_PRIVATE_TOKEN`. That dependency is
-easy to lose track of: merge requests start appearing "by themselves", and months
-later nobody remembers that behind them stands a live account holding an
-`api`-scoped token.
-
-- **Use a service account, not a person.** A personal token disappears when that
-  person leaves the company or rotates their credentials, and every MR the tool
-  opens is attributed to them.
-- **Give the account Developer on the project — no more.** That is enough to read
-  the project and to create, update and merge merge requests.
-- **`CI_JOB_TOKEN` cannot be substituted.** The Merge Requests API is read-only for
-  job tokens, so a personal or project access token with the `api` scope is
-  required.
-- **Plan for rotation.** GitLab no longer issues non-expiring personal access
-  tokens, so expiry is scheduled work. When the token expires, MR creation simply
-  stops — and "no new MRs" is a symptom that is easy to miss for weeks.
-- **Name the account so its purpose is obvious** (for example
-  `svc-gitlab-auto-mr`). Whoever finds it during a directory cleanup will decide
-  its fate based on the name alone; an account called `test1` gets deleted.
 
 ## Building
 
@@ -295,6 +277,15 @@ docker build -t gitlab-auto-mr .
   --reviewer-id "12345,67890"
 ```
 
+### With Labels and a Milestone
+
+```bash
+gitlab-auto-mr --label "bug,priority::high" --milestone 5
+```
+
+Both combine with `--use-issue-name` rather than replacing it: labels are the
+union of the two sources, and an explicit `--milestone` wins over the issue's.
+
 ### Check if MR Exists
 
 ```bash
@@ -333,8 +324,6 @@ Error: unable to get project 12345: unauthorized access, check your access token
 ```
 
 - Check your `GITLAB_PRIVATE_TOKEN` is valid and has `api` scope
-- An expired or revoked token gives the same message — see [Operating](#operating)
-  for who the token should belong to and why rotation is scheduled work
 
 **MR Already Exists**
 

--- a/main.go
+++ b/main.go
@@ -57,6 +57,8 @@ type Config struct {
 	CreateOnly         bool
 	AutoMerge          bool
 	TriggerPipeline    bool
+	Labels             []string
+	MilestoneID        int
 }
 
 type Project struct {
@@ -141,7 +143,7 @@ func main() {
 func parseFlags() (*Config, error) {
 	config := &Config{}
 
-	var userIDsStr, reviewerIDsStr string
+	var userIDsStr, reviewerIDsStr, labelsStr string
 	var showVersion bool
 
 	flag.StringVar(&config.PrivateToken, "private-token", getEnv("GITLAB_PRIVATE_TOKEN", ""), "Private GITLAB token")
@@ -166,6 +168,10 @@ func parseFlags() (*Config, error) {
 	flag.StringVar(&config.Description, "description", "", "Path to description file")
 	flag.StringVar(&config.Description, "d", "", "Path to description file (short)")
 	flag.StringVar(&config.Title, "title", "", "Custom MR title")
+	flag.StringVar(&labelsStr, "label", getEnv("GITLAB_AUTO_MR_LABELS", ""),
+		"Labels to set on the MR (comma-separated)")
+	flag.IntVar(&config.MilestoneID, "milestone", getEnvInt("GITLAB_AUTO_MR_MILESTONE", 0),
+		"Milestone ID to set on the MR")
 	flag.BoolVar(&config.UseIssueName, "use-issue-name", false, "Use issue data from branch name")
 	flag.BoolVar(&config.UseIssueName, "i", false, "Use issue data from branch name (short)")
 	flag.BoolVar(&config.AllowCollaboration, "allow-collaboration", false, "Allow collaboration")
@@ -208,6 +214,7 @@ func parseFlags() (*Config, error) {
 	if reviewerIDsStr != "" {
 		config.ReviewerIDs = parseIntSlice(reviewerIDsStr)
 	}
+	config.Labels = parseStringSlice(labelsStr)
 
 	// Clean GitLab URL if it contains full project URL
 	if strings.Contains(config.GitLabURL, "/") {
@@ -363,15 +370,7 @@ func handleUpdateMR(
 		AllowCollaboration: config.AllowCollaboration,
 	}
 
-	if config.UseIssueName {
-		issueData, err := getIssueData(client, config)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to fetch issue data: %v\n", err)
-		} else {
-			updateRequest.MilestoneID = issueData.Milestone.ID
-			updateRequest.Labels = issueData.Labels
-		}
-	}
+	updateRequest.MilestoneID, updateRequest.Labels = resolveMRMetadata(client, config)
 
 	if err := updateMR(client, config, existingMR.IID, updateRequest); err != nil {
 		return 0, fmt.Errorf("failed to update MR: %v", err)
@@ -397,15 +396,7 @@ func handleCreateMR(
 		AllowCollaboration: config.AllowCollaboration,
 	}
 
-	if config.UseIssueName {
-		issueData, err := getIssueData(client, config)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to fetch issue data: %v\n", err)
-		} else {
-			mrRequest.MilestoneID = issueData.Milestone.ID
-			mrRequest.Labels = issueData.Labels
-		}
-	}
+	mrRequest.MilestoneID, mrRequest.Labels = resolveMRMetadata(client, config)
 
 	createdMR, err := createMR(client, config, mrRequest)
 	if err != nil {
@@ -414,6 +405,60 @@ func handleCreateMR(
 
 	fmt.Printf("Created a new MR %s, assigned to you.\n", title)
 	return createdMR.IID, nil
+}
+
+// resolveMRMetadata determines the milestone and labels for the MR, combining
+// what was given on the command line with what the linked issue carries.
+//
+// --milestone wins over the issue's milestone; labels are the union of the two,
+// with --label values first. A failure to fetch the issue is a warning, not an
+// error: the MR is still worth creating without its issue metadata.
+func resolveMRMetadata(client *http.Client, config *Config) (int, []string) {
+	milestoneID := config.MilestoneID
+	labels := config.Labels
+
+	if !config.UseIssueName {
+		return milestoneID, labels
+	}
+
+	issue, err := getIssueData(client, config)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to fetch issue data: %v\n", err)
+		return milestoneID, labels
+	}
+
+	if milestoneID == 0 {
+		milestoneID = issue.Milestone.ID
+	}
+
+	return milestoneID, mergeLabels(labels, issue.Labels)
+}
+
+// mergeLabels appends the labels from extra that are not already in base,
+// preserving the order of both and never returning a non-nil empty slice
+// (MRCreateRequest.Labels is omitempty, and an empty list would clear labels).
+func mergeLabels(base, extra []string) []string {
+	if len(extra) == 0 {
+		return base
+	}
+
+	seen := make(map[string]struct{}, len(base)+len(extra))
+	merged := make([]string, 0, len(base)+len(extra))
+
+	for _, group := range [][]string{base, extra} {
+		for _, label := range group {
+			if _, ok := seen[label]; ok {
+				continue
+			}
+			seen[label] = struct{}{}
+			merged = append(merged, label)
+		}
+	}
+
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
 }
 
 func enableAutoMerge(client *http.Client, config *Config, mrIID int) error {
@@ -804,6 +849,30 @@ func getEnvInt(key string, defaultValue int) int {
 
 func boolPtr(b bool) *bool {
 	return &b
+}
+
+// parseStringSlice splits a comma-separated flag value, trimming each element
+// and dropping empty ones. Returns nil for an empty input so the field stays
+// omitted from the JSON request rather than being sent as an empty list.
+func parseStringSlice(s string) []string {
+	if s == "" {
+		return nil
+	}
+
+	parts := strings.Split(s, ",")
+	result := make([]string, 0, len(parts))
+
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			result = append(result, part)
+		}
+	}
+
+	if len(result) == 0 {
+		return nil
+	}
+	return result
 }
 
 func parseIntSlice(s string) []int {

--- a/main.go
+++ b/main.go
@@ -216,6 +216,10 @@ func parseFlags() (*Config, error) {
 	}
 	config.Labels = parseStringSlice(labelsStr)
 
+	if config.MilestoneID < 0 {
+		return nil, fmt.Errorf("--milestone must not be negative, got %d", config.MilestoneID)
+	}
+
 	// Clean GitLab URL if it contains full project URL
 	if strings.Contains(config.GitLabURL, "/") {
 		re := regexp.MustCompile(`^https?://[^/]+`)
@@ -439,6 +443,9 @@ func resolveMRMetadata(client *http.Client, config *Config) (int, []string) {
 // (MRCreateRequest.Labels is omitempty, and an empty list would clear labels).
 func mergeLabels(base, extra []string) []string {
 	if len(extra) == 0 {
+		if len(base) == 0 {
+			return nil
+		}
 		return base
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -1641,6 +1641,7 @@ func TestMergeLabels(t *testing.T) {
 		expected []string
 	}{
 		{"both empty", nil, nil, nil},
+		{"empty non-nil base stays nil", []string{}, nil, nil},
 		{"only base", []string{"bug"}, nil, []string{"bug"}},
 		{"only extra", nil, []string{"issue-label"}, []string{"issue-label"}},
 		{"union", []string{"bug"}, []string{"backend"}, []string{"bug", "backend"}},
@@ -2000,6 +2001,15 @@ func TestParseFlags(t *testing.T) {
 					t.Errorf("MilestoneID = %d, want 5", c.MilestoneID)
 				}
 			},
+		},
+		{
+			name: "negative-milestone",
+			args: []string{"prog", "--milestone", "-1"},
+			setup: func(t *testing.T) {
+				setRequiredParseEnv(t)
+			},
+			wantErr:   true,
+			errSubstr: "--milestone must not be negative",
 		},
 		{
 			name: "labels-and-milestone-flags-override-env",

--- a/main_test.go
+++ b/main_test.go
@@ -1603,6 +1603,187 @@ func TestRunWithIssueDataError(t *testing.T) {
 	}
 }
 
+func TestParseStringSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{"empty", "", nil},
+		{"single", "bug", []string{"bug"}},
+		{"multiple", "bug,priority::high", []string{"bug", "priority::high"}},
+		{"trims spaces", " bug , needs-review ", []string{"bug", "needs-review"}},
+		{"drops empty elements", "bug,,, ,review", []string{"bug", "review"}},
+		{"only separators", ",,,", nil},
+		{"keeps inner spaces", "needs review,done", []string{"needs review", "done"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseStringSlice(tt.input)
+			if len(got) != len(tt.expected) {
+				t.Fatalf("parseStringSlice(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+			for i := range got {
+				if got[i] != tt.expected[i] {
+					t.Errorf("parseStringSlice(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestMergeLabels(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     []string
+		extra    []string
+		expected []string
+	}{
+		{"both empty", nil, nil, nil},
+		{"only base", []string{"bug"}, nil, []string{"bug"}},
+		{"only extra", nil, []string{"issue-label"}, []string{"issue-label"}},
+		{"union", []string{"bug"}, []string{"backend"}, []string{"bug", "backend"}},
+		{"deduplicates", []string{"bug", "backend"}, []string{"backend", "ci"}, []string{"bug", "backend", "ci"}},
+		{"base order first", []string{"z", "a"}, []string{"a", "m"}, []string{"z", "a", "m"}},
+		{"case sensitive", []string{"Bug"}, []string{"bug"}, []string{"Bug", "bug"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeLabels(tt.base, tt.extra)
+			if len(got) != len(tt.expected) {
+				t.Fatalf("mergeLabels(%v, %v) = %v, want %v", tt.base, tt.extra, got, tt.expected)
+			}
+			for i := range got {
+				if got[i] != tt.expected[i] {
+					t.Errorf("mergeLabels(%v, %v)[%d] = %q, want %q", tt.base, tt.extra, i, got[i], tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+// newIssueMetadataServer serves a project, no existing MR, and an issue carrying
+// milestone 99 and labels ["from-issue", "shared"]. It records the create request.
+func newIssueMetadataServer(t *testing.T, captured *MRCreateRequest) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v4/projects/123" && r.Method == "GET":
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(Project{ID: 123, DefaultBranch: "main"}); err != nil {
+				t.Errorf("encode project: %v", err)
+			}
+		case r.URL.Path == "/api/v4/projects/123/merge_requests" && r.Method == "GET":
+			w.Header().Set("Content-Type", "application/json")
+			if _, err := w.Write([]byte("[]")); err != nil {
+				t.Errorf("write empty MR list: %v", err)
+			}
+		case r.URL.Path == "/api/v4/projects/123/issues/42" && r.Method == "GET":
+			w.Header().Set("Content-Type", "application/json")
+			if _, err := w.Write([]byte(
+				`{"id":1,"iid":42,"title":"Issue","labels":["from-issue","shared"],"milestone":{"id":99}}`,
+			)); err != nil {
+				t.Errorf("write issue: %v", err)
+			}
+		case r.URL.Path == "/api/v4/projects/123/merge_requests" && r.Method == "POST":
+			if err := json.NewDecoder(r.Body).Decode(captured); err != nil {
+				t.Errorf("decode create request: %v", err)
+			}
+			w.WriteHeader(http.StatusCreated)
+			if err := json.NewEncoder(w).Encode(MergeRequest{ID: 1, IID: 7}); err != nil {
+				t.Errorf("encode MR: %v", err)
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+// TestRunLabelAndMilestone covers issues #73 and #74: labels and a milestone can
+// be set from the command line, they combine with --use-issue-name rather than
+// excluding it, and an explicit milestone wins over the issue's.
+func TestRunLabelAndMilestone(t *testing.T) {
+	tests := []struct {
+		name             string
+		labels           []string
+		milestoneID      int
+		useIssueName     bool
+		expectedLabels   []string
+		expectedMileston int
+	}{
+		{
+			name:             "flags only",
+			labels:           []string{"bug", "priority::high"},
+			milestoneID:      5,
+			expectedLabels:   []string{"bug", "priority::high"},
+			expectedMileston: 5,
+		},
+		{
+			name:             "issue only",
+			useIssueName:     true,
+			expectedLabels:   []string{"from-issue", "shared"},
+			expectedMileston: 99,
+		},
+		{
+			name:             "labels merge with issue labels",
+			labels:           []string{"bug", "shared"},
+			useIssueName:     true,
+			expectedLabels:   []string{"bug", "shared", "from-issue"},
+			expectedMileston: 99,
+		},
+		{
+			name:             "explicit milestone beats issue milestone",
+			milestoneID:      5,
+			useIssueName:     true,
+			expectedLabels:   []string{"from-issue", "shared"},
+			expectedMileston: 5,
+		},
+		{
+			name:             "neither",
+			expectedLabels:   nil,
+			expectedMileston: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured MRCreateRequest
+			server := newIssueMetadataServer(t, &captured)
+			defer server.Close()
+
+			config := &Config{
+				PrivateToken: "test-token",
+				SourceBranch: "feature/#42-test",
+				ProjectID:    123,
+				GitLabURL:    server.URL,
+				UserIDs:      []int{1},
+				TargetBranch: "main",
+				Labels:       tt.labels,
+				MilestoneID:  tt.milestoneID,
+				UseIssueName: tt.useIssueName,
+			}
+
+			if err := run(config); err != nil {
+				t.Fatalf("run() error = %v", err)
+			}
+
+			if captured.MilestoneID != tt.expectedMileston {
+				t.Errorf("MilestoneID = %d, want %d", captured.MilestoneID, tt.expectedMileston)
+			}
+			if len(captured.Labels) != len(tt.expectedLabels) {
+				t.Fatalf("Labels = %v, want %v", captured.Labels, tt.expectedLabels)
+			}
+			for i := range captured.Labels {
+				if captured.Labels[i] != tt.expectedLabels[i] {
+					t.Errorf("Labels[%d] = %q, want %q", i, captured.Labels[i], tt.expectedLabels[i])
+				}
+			}
+		})
+	}
+}
+
 // resetFlagSet replaces the package-level flag.CommandLine with a fresh FlagSet
 // using ContinueOnError. parseFlags re-registers every flag on flag.CommandLine,
 // so without a reset the second subtest would panic with "flag redefined".
@@ -1628,6 +1809,8 @@ func clearRequiredParseEnv(t *testing.T) {
 		"CI_PROJECT_URL",
 		"GITLAB_USER_ID",
 		"GITLAB_AUTO_MR_TARGET_BRANCH",
+		"GITLAB_AUTO_MR_LABELS",
+		"GITLAB_AUTO_MR_MILESTONE",
 	} {
 		t.Setenv(key, "")
 	}
@@ -1797,6 +1980,42 @@ func TestParseFlags(t *testing.T) {
 				// run() substitutes the project's default branch when this is empty.
 				if c.TargetBranch != "" {
 					t.Errorf("TargetBranch = %q, want empty", c.TargetBranch)
+				}
+			},
+		},
+		{
+			name: "labels-and-milestone-from-env",
+			args: []string{"prog"},
+			setup: func(t *testing.T) {
+				setRequiredParseEnv(t)
+				t.Setenv("GITLAB_AUTO_MR_LABELS", "bug, needs-review")
+				t.Setenv("GITLAB_AUTO_MR_MILESTONE", "5")
+			},
+			checkConfig: func(t *testing.T, c *Config) {
+				t.Helper()
+				if len(c.Labels) != 2 || c.Labels[0] != "bug" || c.Labels[1] != "needs-review" {
+					t.Errorf("Labels = %v, want [bug needs-review]", c.Labels)
+				}
+				if c.MilestoneID != 5 {
+					t.Errorf("MilestoneID = %d, want 5", c.MilestoneID)
+				}
+			},
+		},
+		{
+			name: "labels-and-milestone-flags-override-env",
+			args: []string{"prog", "--label", "ci", "--milestone", "9"},
+			setup: func(t *testing.T) {
+				setRequiredParseEnv(t)
+				t.Setenv("GITLAB_AUTO_MR_LABELS", "bug")
+				t.Setenv("GITLAB_AUTO_MR_MILESTONE", "5")
+			},
+			checkConfig: func(t *testing.T, c *Config) {
+				t.Helper()
+				if len(c.Labels) != 1 || c.Labels[0] != "ci" {
+					t.Errorf("Labels = %v, want [ci]", c.Labels)
+				}
+				if c.MilestoneID != 9 {
+					t.Errorf("MilestoneID = %d, want 9", c.MilestoneID)
 				}
 			},
 		},


### PR DESCRIPTION
Closes #73, closes #74. The two are one change in practice — both values travel the same path into `MRCreateRequest`/`MRUpdateRequest`, and their interaction with `--use-issue-name` has to be decided together.

## Behaviour

```bash
gitlab-auto-mr --label "bug,priority::high,needs-review" --milestone 5
```

Also readable from `GITLAB_AUTO_MR_LABELS` and `GITLAB_AUTO_MR_MILESTONE`, flag winning over env.

Combining with `--use-issue-name`, as the issues asked:

| | result |
|---|---|
| labels | union of `--label` and the issue's, `--label` values first, duplicates dropped |
| milestone | `--milestone` if given, otherwise the issue's |

Label comparison is exact — GitLab treats `Bug` and `bug` as different labels, so folding case would silently merge two real ones.

## Implementation note

`handleCreateMR` and `handleUpdateMR` each carried an identical copy of the fetch-issue-and-assign block. Both now call one `resolveMRMetadata`, which does the fetch, applies the precedence rules, and keeps the existing "a failed issue fetch is a warning, not an error" behaviour. That is a net deletion in the two handlers and removes the codebase's clearest `dupl` candidate.

`mergeLabels` returns `nil` rather than an empty slice when there is nothing to send: `Labels` is `omitempty`, and sending `[]` to GitLab would *clear* the labels on an update rather than leave them alone.

## Tests

- `TestParseStringSlice` — trimming, empty elements, all-separator input, inner spaces preserved.
- `TestMergeLabels` — union, dedup, ordering, case sensitivity.
- `TestRunLabelAndMilestone` — five cases through `run()` against a mock GitLab that serves an issue with milestone 99 and labels `["from-issue","shared"]`, asserting on the captured create request: flags only, issue only, merged labels with an overlap, explicit milestone beating the issue's, and neither set.
- Two `TestParseFlags` subtests for the env vars and for flags overriding them.

```
$ go test ./...
ok  	gitlab-auto-mr
$ golangci-lint run
0 issues.
```