### PR TITLE
feat: print the MR URL after create, update and existence checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ create_mr:
     - if: $CI_COMMIT_BRANCH != "main" && $CI_PIPELINE_SOURCE != "merge_request_event"
 ```
 
+Every run that identifies an MR prints its browser URL, so it can be clicked
+straight out of the job log:
+
+```
+Created a new MR Draft: feature/new-thing, assigned to you.
+MR URL: https://gitlab.example.com/group/project/-/merge_requests/42
+```
+
 #### Update Existing MR
 
 ```yaml
@@ -329,6 +337,7 @@ Error: unable to get project 12345: unauthorized access, check your access token
 
 ```
 Merge request already exists: Feature XYZ (IID: 42). Use --update-mr flag to update it.
+MR URL: https://gitlab.example.com/group/project/-/merge_requests/42
 ```
 
 - This is the default behavior when MR already exists

--- a/main.go
+++ b/main.go
@@ -74,6 +74,7 @@ type MergeRequest struct {
 	SourceBranch string `json:"source_branch"`
 	TargetBranch string `json:"target_branch"`
 	State        string `json:"state"`
+	WebURL       string `json:"web_url"`
 }
 
 type Pipeline struct {
@@ -262,6 +263,7 @@ func checkMRExists(config *Config, existingMR *MergeRequest) {
 	} else {
 		fmt.Printf("Merge request exists: %s (IID: %d)\n",
 			existingMR.Title, existingMR.IID)
+		printMRURL(existingMR)
 	}
 }
 
@@ -350,6 +352,7 @@ func handleMR(
 				existingMR.Title, existingMR.IID,
 			)
 		}
+		printMRURL(existingMR)
 		return existingMR.IID, nil
 
 	case existingMR != nil:
@@ -381,6 +384,7 @@ func handleUpdateMR(
 	}
 
 	fmt.Printf("Updated existing MR %s (IID: %d)\n", title, existingMR.IID)
+	printMRURL(existingMR)
 	return existingMR.IID, nil
 }
 
@@ -408,6 +412,7 @@ func handleCreateMR(
 	}
 
 	fmt.Printf("Created a new MR %s, assigned to you.\n", title)
+	printMRURL(createdMR)
 	return createdMR.IID, nil
 }
 
@@ -466,6 +471,17 @@ func mergeLabels(base, extra []string) []string {
 		return nil
 	}
 	return merged
+}
+
+// printMRURL writes the MR's browser URL so it can be clicked straight out of a
+// CI job log. The URL comes from the API response rather than being assembled
+// locally: --gitlab-url is only the instance host, so the project path with its
+// namespace is not knowable here. Nothing is printed if GitLab omitted web_url.
+func printMRURL(mr *MergeRequest) {
+	if mr == nil || mr.WebURL == "" {
+		return
+	}
+	fmt.Printf("MR URL: %s\n", mr.WebURL)
 }
 
 func enableAutoMerge(client *http.Client, config *Config, mrIID int) error {

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -1780,6 +1781,142 @@ func TestRunLabelAndMilestone(t *testing.T) {
 				if captured.Labels[i] != tt.expectedLabels[i] {
 					t.Errorf("Labels[%d] = %q, want %q", i, captured.Labels[i], tt.expectedLabels[i])
 				}
+			}
+		})
+	}
+}
+
+// captureOutput runs fn with os.Stdout redirected to a pipe and returns what it
+// wrote. The pipe is drained on a goroutine so a write larger than the pipe
+// buffer cannot deadlock.
+func captureOutput(t *testing.T, fn func()) string {
+	t.Helper()
+
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		if _, cerr := io.Copy(&buf, r); cerr != nil {
+			t.Errorf("drain pipe: %v", cerr)
+		}
+		done <- buf.String()
+	}()
+
+	fn()
+
+	os.Stdout = orig
+	if cerr := w.Close(); cerr != nil {
+		t.Errorf("close pipe writer: %v", cerr)
+	}
+	out := <-done
+	if cerr := r.Close(); cerr != nil {
+		t.Errorf("close pipe reader: %v", cerr)
+	}
+	return out
+}
+
+// TestPrintMRURL covers issue #75: the MR's browser URL is printed after every
+// operation that identifies an MR, and nothing is printed when GitLab did not
+// return one.
+func TestPrintMRURL(t *testing.T) {
+	const webURL = "https://gitlab.example.com/group/proj/-/merge_requests/42"
+
+	tests := []struct {
+		name      string
+		existing  string // JSON body for the MR list endpoint
+		createdMR string // JSON body for the create response
+		config    func(c *Config)
+		wantURL   bool
+	}{
+		{
+			name:      "created",
+			existing:  "[]",
+			createdMR: `{"id":1,"iid":42,"web_url":"` + webURL + `"}`,
+			wantURL:   true,
+		},
+		{
+			name:      "created without web_url",
+			existing:  "[]",
+			createdMR: `{"id":1,"iid":42}`,
+			wantURL:   false,
+		},
+		{
+			name:     "updated",
+			existing: `[{"id":1,"iid":42,"title":"Old","web_url":"` + webURL + `"}]`,
+			config:   func(c *Config) { c.UpdateMR = true },
+			wantURL:  true,
+		},
+		{
+			name:     "exists without update flag",
+			existing: `[{"id":1,"iid":42,"title":"Old","web_url":"` + webURL + `"}]`,
+			wantURL:  true,
+		},
+		{
+			name:     "dry run",
+			existing: `[{"id":1,"iid":42,"title":"Old","web_url":"` + webURL + `"}]`,
+			config:   func(c *Config) { c.MRExists = true },
+			wantURL:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case r.URL.Path == "/api/v4/projects/123" && r.Method == "GET":
+					if err := json.NewEncoder(w).Encode(Project{ID: 123, DefaultBranch: "main"}); err != nil {
+						t.Errorf("encode project: %v", err)
+					}
+				case r.URL.Path == "/api/v4/projects/123/merge_requests" && r.Method == "GET":
+					if _, err := w.Write([]byte(tt.existing)); err != nil {
+						t.Errorf("write MR list: %v", err)
+					}
+				case r.URL.Path == "/api/v4/projects/123/merge_requests" && r.Method == "POST":
+					w.WriteHeader(http.StatusCreated)
+					if _, err := w.Write([]byte(tt.createdMR)); err != nil {
+						t.Errorf("write created MR: %v", err)
+					}
+				case r.URL.Path == "/api/v4/projects/123/merge_requests/42" && r.Method == "PUT":
+					if _, err := w.Write([]byte(`{}`)); err != nil {
+						t.Errorf("write update response: %v", err)
+					}
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			config := &Config{
+				PrivateToken: "test-token",
+				SourceBranch: "feature/test",
+				ProjectID:    123,
+				GitLabURL:    server.URL,
+				UserIDs:      []int{1},
+				TargetBranch: "main",
+			}
+			if tt.config != nil {
+				tt.config(config)
+			}
+
+			var runErr error
+			out := captureOutput(t, func() { runErr = run(config) })
+			if runErr != nil {
+				t.Fatalf("run() error = %v", runErr)
+			}
+
+			gotURL := strings.Contains(out, "MR URL: "+webURL)
+			if gotURL != tt.wantURL {
+				t.Errorf("URL printed = %v, want %v; output was:\n%s", gotURL, tt.wantURL, out)
+			}
+			if !tt.wantURL && strings.Contains(out, "MR URL:") {
+				t.Errorf("expected no MR URL line, output was:\n%s", out)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #75.

```
Created a new MR Draft: feature/new-thing, assigned to you.
MR URL: https://gitlab.example.com/group/project/-/merge_requests/42
```

Printed on every path that identifies an MR, not just creation — updating one, finding one that already exists, and the `--mr-exists` dry run all now end with the link. Those are the cases where you most want to click through.

## Two decisions worth flagging

**The URL comes from the API, not from string assembly.** `--gitlab-url` is reduced to the instance host in `parseFlags` (the regexp keeps only `scheme://host`), so the project path with its namespace is not available locally. `web_url` is in every MR response GitLab sends — the create response and the list response both carry it — so `MergeRequest` just gained the field. When it is absent, no line is printed rather than a guessed one.

**Plain `MR URL:` rather than the `✅` / `🔗` prefixes sketched in the issue.** The existing output is plain ASCII throughout, and this text lands in CI job logs that are not reliably UTF-8-rendering. Happy to switch to the emoji form if you prefer it — it is one string.

## Tests

`TestPrintMRURL` drives `run()` against a mock GitLab for five cases: created, created with no `web_url` in the response (asserting *nothing* is printed), updated, already-exists-without-`--update-mr`, and `--mr-exists`. It uses a new `captureOutput` helper that drains the pipe on a goroutine, so a large write cannot deadlock the test.

```
$ go test ./...
ok  	gitlab-auto-mr
$ golangci-lint run
0 issues.
```