### PR TITLE
chore: ignore the dash-named build artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 *.dylib
 gitlab_auto_mr
 gitlab_auto_mr-*
+# The Taskfile and Dockerfile build `gitlab_auto_mr`, but `go build` without -o
+# names the binary after the module directory — with a dash.
+gitlab-auto-mr
+gitlab-auto-mr-*
 
 # Test files
 *.test


### PR DESCRIPTION
`.gitignore` covers `gitlab_auto_mr` — the name the Taskfile and the Dockerfile use:

```
gitlab_auto_mr
gitlab_auto_mr-*
```

A plain `go build` (no `-o`) names the binary after the module directory instead: `gitlab-auto-mr`, with a dash. That spelling is not ignored, so the 8.5 MB executable sits in `git status` as untracked and rides along with any `git add -A`.

This is not hypothetical — **#155 and #156 both currently carry `gitlab-auto-mr`**. `gh` reports it as `+0 -0` because it does not count lines in binary files, so it is invisible in the diff summary.

Two notes:

- `.gitignore` does not affect files already staged in those branches — they need `git rm --cached gitlab-auto-mr` before merging, otherwise the blob lands in history permanently and only a rewrite can remove it.
- #155 also carries `progress.md`. I left it out of this change deliberately: I cannot tell whether it is meant to be a project document or a scratch file. If it is scratch, it belongs here too.

Verified locally: `git check-ignore -v gitlab-auto-mr` → `.gitignore:11`, and the file disappears from `git status`.