### PR TITLE
refactor: route every API call through one request helper, with context

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ union of the two sources, and an explicit `--milestone` wins over the issue's.
 **Authentication Error**
 
 ```
-Error: unable to get project 12345: unauthorized access, check your access token is valid
+Error: unable to get project 12345: unauthorized access, check your access token is valid and has the api scope
 ```
 
 - Check your `GITLAB_PRIVATE_TOKEN` is valid and has `api` scope

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -11,9 +12,11 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/signal"
 	"regexp"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -138,8 +141,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := run(config); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+	// Canceling on SIGINT/SIGTERM aborts the in-flight request instead of
+	// leaving the process to sit out the client timeout. stop() is called
+	// directly rather than deferred, since os.Exit below would skip a defer.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	runErr := run(ctx, config)
+	stop()
+
+	if runErr != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", runErr)
 		os.Exit(1)
 	}
 }
@@ -276,16 +286,16 @@ func checkMRExists(config *Config, existingMR *MergeRequest) {
 	}
 }
 
-func run(config *Config) error {
+func run(ctx context.Context, config *Config) error {
 	if err := validateConfig(config); err != nil {
 		return err
 	}
 
 	client := createHTTPClient(config.Insecure)
 
-	project, err := getProject(client, config)
+	project, err := getProject(ctx, client, config)
 	if err != nil {
-		return fmt.Errorf("unable to get project %d: %v", config.ProjectID, err)
+		return fmt.Errorf("unable to get project %d: %w", config.ProjectID, err)
 	}
 
 	if config.TargetBranch == "" {
@@ -296,9 +306,9 @@ func run(config *Config) error {
 		return err
 	}
 
-	existingMR, err := getExistingMR(client, config)
+	existingMR, err := getExistingMR(ctx, client, config)
 	if err != nil {
-		return fmt.Errorf("failed to check if MR exists: %v", err)
+		return fmt.Errorf("failed to check if MR exists: %w", err)
 	}
 
 	if config.MRExists {
@@ -313,7 +323,7 @@ func run(config *Config) error {
 	title := getMRTitle(config.CommitPrefix, config.Title, config.SourceBranch)
 	description := getDescriptionData(config.Description)
 
-	mr, err := handleMR(client, config, existingMR, title, description)
+	mr, err := handleMR(ctx, client, config, existingMR, title, description)
 	if err != nil {
 		return err
 	}
@@ -323,13 +333,13 @@ func run(config *Config) error {
 	}
 
 	if config.TriggerPipeline {
-		if err := triggerMRPipeline(client, config, mr); err != nil {
-			return fmt.Errorf("failed to trigger merge request pipeline: %v", err)
+		if err := triggerMRPipeline(ctx, client, config, mr); err != nil {
+			return fmt.Errorf("failed to trigger merge request pipeline: %w", err)
 		}
 	}
 
 	if config.AutoMerge {
-		return enableAutoMerge(client, config, mr.IID)
+		return enableAutoMerge(ctx, client, config, mr.IID)
 	}
 
 	return nil
@@ -358,7 +368,7 @@ func checkMRMode(config *Config, existingMR *MergeRequest) error {
 }
 
 func handleMR(
-	client *http.Client, config *Config,
+	ctx context.Context, client *http.Client, config *Config,
 	existingMR *MergeRequest, title, description string,
 ) (*MergeRequest, error) {
 	switch {
@@ -379,15 +389,15 @@ func handleMR(
 		return existingMR, nil
 
 	case existingMR != nil:
-		return handleUpdateMR(client, config, existingMR, title, description)
+		return handleUpdateMR(ctx, client, config, existingMR, title, description)
 
 	default:
-		return handleCreateMR(client, config, title, description)
+		return handleCreateMR(ctx, client, config, title, description)
 	}
 }
 
 func handleUpdateMR(
-	client *http.Client, config *Config,
+	ctx context.Context, client *http.Client, config *Config,
 	existingMR *MergeRequest, title, description string,
 ) (*MergeRequest, error) {
 	updateRequest := &MRUpdateRequest{
@@ -400,10 +410,10 @@ func handleUpdateMR(
 		AllowCollaboration: config.AllowCollaboration,
 	}
 
-	updateRequest.MilestoneID, updateRequest.Labels = resolveMRMetadata(client, config)
+	updateRequest.MilestoneID, updateRequest.Labels = resolveMRMetadata(ctx, client, config)
 
-	if err := updateMR(client, config, existingMR.IID, updateRequest); err != nil {
-		return nil, fmt.Errorf("failed to update MR: %v", err)
+	if err := updateMR(ctx, client, config, existingMR.IID, updateRequest); err != nil {
+		return nil, fmt.Errorf("failed to update MR: %w", err)
 	}
 
 	fmt.Printf("Updated existing MR %s (IID: %d)\n", title, existingMR.IID)
@@ -412,7 +422,7 @@ func handleUpdateMR(
 }
 
 func handleCreateMR(
-	client *http.Client, config *Config,
+	ctx context.Context, client *http.Client, config *Config,
 	title, description string,
 ) (*MergeRequest, error) {
 	mrRequest := &MRCreateRequest{
@@ -427,11 +437,11 @@ func handleCreateMR(
 		AllowCollaboration: config.AllowCollaboration,
 	}
 
-	mrRequest.MilestoneID, mrRequest.Labels = resolveMRMetadata(client, config)
+	mrRequest.MilestoneID, mrRequest.Labels = resolveMRMetadata(ctx, client, config)
 
-	createdMR, err := createMR(client, config, mrRequest)
+	createdMR, err := createMR(ctx, client, config, mrRequest)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create MR: %v", err)
+		return nil, fmt.Errorf("failed to create MR: %w", err)
 	}
 
 	fmt.Printf("Created a new MR %s, assigned to you.\n", title)
@@ -445,7 +455,7 @@ func handleCreateMR(
 // --milestone wins over the issue's milestone; labels are the union of the two,
 // with --label values first. A failure to fetch the issue is a warning, not an
 // error: the MR is still worth creating without its issue metadata.
-func resolveMRMetadata(client *http.Client, config *Config) (int, []string) {
+func resolveMRMetadata(ctx context.Context, client *http.Client, config *Config) (int, []string) {
 	milestoneID := config.MilestoneID
 	labels := config.Labels
 
@@ -453,7 +463,7 @@ func resolveMRMetadata(client *http.Client, config *Config) (int, []string) {
 		return milestoneID, labels
 	}
 
-	issue, err := getIssueData(client, config)
+	issue, err := getIssueData(ctx, client, config)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to fetch issue data: %v\n", err)
 		return milestoneID, labels
@@ -507,14 +517,14 @@ func printMRURL(mr *MergeRequest) {
 	fmt.Printf("MR URL: %s\n", mr.WebURL)
 }
 
-func enableAutoMerge(client *http.Client, config *Config, mrIID int) error {
+func enableAutoMerge(ctx context.Context, client *http.Client, config *Config, mrIID int) error {
 	if mrIID == 0 {
 		fmt.Println("Warning: could not determine MR IID, skipping auto-merge")
 		return nil
 	}
 
-	if err := acceptMR(client, config, mrIID); err != nil {
-		return fmt.Errorf("failed to enable auto-merge: %v", err)
+	if err := acceptMR(ctx, client, config, mrIID); err != nil {
+		return fmt.Errorf("failed to enable auto-merge: %w", err)
 	}
 
 	fmt.Printf("Auto-merge enabled for MR (IID: %d)\n", mrIID)
@@ -533,14 +543,14 @@ func enableAutoMerge(client *http.Client, config *Config, mrIID int) error {
 // exactly when the checks are worth re-running. To keep that from producing a
 // pipeline per job run, an existing pipeline for the same commit is left alone
 // unless --force-pipeline says otherwise.
-func triggerMRPipeline(client *http.Client, config *Config, mr *MergeRequest) error {
+func triggerMRPipeline(ctx context.Context, client *http.Client, config *Config, mr *MergeRequest) error {
 	if mr == nil || mr.IID == 0 {
 		fmt.Println("Warning: could not determine MR IID, skipping pipeline trigger")
 		return nil
 	}
 
 	if !config.ForcePipeline {
-		existing, err := findPipelineForSHA(client, config, mr)
+		existing, err := findPipelineForSHA(ctx, client, config, mr)
 		if err != nil {
 			// Not being able to list pipelines is no reason to skip creating one;
 			// the worst case is the duplicate this check exists to avoid.
@@ -555,57 +565,42 @@ func triggerMRPipeline(client *http.Client, config *Config, mr *MergeRequest) er
 		}
 	}
 
-	apiURL := fmt.Sprintf(
-		"%s/api/v4/projects/%d/merge_requests/%d/pipelines",
-		config.GitLabURL, config.ProjectID, mr.IID,
-	)
-
-	req, err := http.NewRequest("POST", apiURL, http.NoBody)
+	body, err := doRequest(ctx, client, config, http.MethodPost,
+		fmt.Sprintf("projects/%d/merge_requests/%d/pipelines", config.ProjectID, mr.IID), nil)
 	if err != nil {
-		return err
-	}
-
-	req.Header.Set("PRIVATE-TOKEN", config.PrivateToken)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	switch resp.StatusCode {
-	case 200, 201:
-		// The pipeline already exists at this point, so a response we cannot read
-		// is worth a warning but must not fail the run: the body is only used to
-		// tell the user what was created.
-		var pipeline Pipeline
-		if err := json.NewDecoder(resp.Body).Decode(&pipeline); err != nil {
-			fmt.Printf("Warning: merge request pipeline created but response could not be read: %v\n", err)
-			return nil
+		var apiErr *apiError
+		if errors.As(err, &apiErr) {
+			switch apiErr.StatusCode {
+			case http.StatusForbidden:
+				return fmt.Errorf(
+					"forbidden, the token owner needs at least the Developer role on the project " +
+						"to create pipelines",
+				)
+			case http.StatusBadRequest:
+				return fmt.Errorf(
+					"GitLab refused to create the pipeline, "+
+						"the CI configuration may define no jobs for merge request pipelines: %s",
+					apiErr.Body,
+				)
+			}
 		}
-		fmt.Printf(
-			"Merge request pipeline created (ID: %d, status: %s)%s\n",
-			pipeline.ID, pipeline.Status, urlSuffix(pipeline.WebURL),
-		)
-		return nil
-	case 401:
-		return fmt.Errorf("unauthorized access, check your access token permissions")
-	case 403:
-		return fmt.Errorf(
-			"forbidden, the token owner needs at least the Developer role on the project " +
-				"to create pipelines",
-		)
-	case 400:
-		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf(
-			"GitLab refused to create the pipeline, "+
-				"the CI configuration may define no jobs for merge request pipelines: %s",
-			string(respBody),
-		)
-	default:
-		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
+		return err
 	}
+
+	// The pipeline already exists at this point, so a response we cannot read is
+	// worth a warning but must not fail the run: the body is only used to tell
+	// the user what was created.
+	var pipeline Pipeline
+	if err := json.Unmarshal(body, &pipeline); err != nil {
+		fmt.Printf("Warning: merge request pipeline created but response could not be read: %v\n", err)
+		return nil
+	}
+
+	fmt.Printf(
+		"Merge request pipeline created (ID: %d, status: %s)%s\n",
+		pipeline.ID, pipeline.Status, urlSuffix(pipeline.WebURL),
+	)
+	return nil
 }
 
 // findPipelineForSHA returns the MR's existing pipeline for its head commit, or
@@ -614,36 +609,21 @@ func triggerMRPipeline(client *http.Client, config *Config, mr *MergeRequest) er
 // With an unknown head SHA there is nothing to compare against, so it reports
 // no match and the caller creates a pipeline: a duplicate is a better outcome
 // than silently skipping the checks.
-func findPipelineForSHA(client *http.Client, config *Config, mr *MergeRequest) (*Pipeline, error) {
+func findPipelineForSHA(
+	ctx context.Context, client *http.Client, config *Config, mr *MergeRequest,
+) (*Pipeline, error) {
 	if mr.SHA == "" {
 		return nil, nil
 	}
 
-	apiURL := fmt.Sprintf(
-		"%s/api/v4/projects/%d/merge_requests/%d/pipelines",
-		config.GitLabURL, config.ProjectID, mr.IID,
-	)
-
-	req, err := http.NewRequest("GET", apiURL, http.NoBody)
+	body, err := doRequest(ctx, client, config, http.MethodGet,
+		fmt.Sprintf("projects/%d/merge_requests/%d/pipelines", config.ProjectID, mr.IID), nil)
 	if err != nil {
 		return nil, err
-	}
-
-	req.Header.Set("PRIVATE-TOKEN", config.PrivateToken)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		respBody, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
 	}
 
 	var pipelines []Pipeline
-	if err := json.NewDecoder(resp.Body).Decode(&pipelines); err != nil {
+	if err := json.Unmarshal(body, &pipelines); err != nil {
 		return nil, err
 	}
 
@@ -690,15 +670,60 @@ func createHTTPClient(insecure bool) *http.Client {
 	return client
 }
 
-func getProject(client *http.Client, config *Config) (*Project, error) {
-	apiURL := fmt.Sprintf("%s/api/v4/projects/%d", config.GitLabURL, config.ProjectID)
+// apiError is returned by doRequest when GitLab answered with a status the
+// helper does not treat as success. Callers use errors.As to give the statuses
+// that mean something specific to their endpoint a message of their own; the
+// rest fall through to Error(), which is the wording every API function used to
+// build by hand.
+type apiError struct {
+	StatusCode int
+	Body       string
+}
 
-	req, err := http.NewRequest("GET", apiURL, http.NoBody)
+func (e *apiError) Error() string {
+	if e.Body == "" {
+		return fmt.Sprintf("HTTP %d", e.StatusCode)
+	}
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+// errUnauthorized is returned for every 401. GitLab answers 401 for the same
+// reason on every endpoint, so the advice lives in one place rather than being
+// re-worded per function.
+var errUnauthorized = errors.New("unauthorized access, check your access token is valid and has the api scope")
+
+// doRequest performs one GitLab API call and returns the raw response body.
+//
+// path is relative to /api/v4 and must already be escaped. body, when non-nil,
+// is sent as JSON. Any 2xx is success; 401 yields errUnauthorized and every
+// other status yields *apiError carrying the code and body.
+//
+// Decoding is left to the caller: the bodies are single objects, small enough
+// to hold in memory, and each caller has its own wording for a malformed one.
+func doRequest(
+	ctx context.Context, client *http.Client, config *Config,
+	method, path string, body any,
+) ([]byte, error) {
+	apiURL := fmt.Sprintf("%s/api/v4/%s", config.GitLabURL, path)
+
+	var reader io.Reader = http.NoBody
+	if body != nil {
+		jsonData, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		reader = bytes.NewBuffer(jsonData)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, apiURL, reader)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("PRIVATE-TOKEN", config.PrivateToken)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -706,16 +731,31 @@ func getProject(client *http.Client, config *Config) (*Project, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == 401 {
-		return nil, fmt.Errorf("unauthorized access, check your access token is valid")
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
 	}
 
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, errUnauthorized
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, &apiError{StatusCode: resp.StatusCode, Body: string(respBody)}
+	}
+
+	return respBody, nil
+}
+
+func getProject(ctx context.Context, client *http.Client, config *Config) (*Project, error) {
+	body, err := doRequest(ctx, client, config, http.MethodGet,
+		fmt.Sprintf("projects/%d", config.ProjectID), nil)
+	if err != nil {
+		return nil, err
 	}
 
 	var project Project
-	if err := json.NewDecoder(resp.Body).Decode(&project); err != nil {
+	if err := json.Unmarshal(body, &project); err != nil {
 		return nil, err
 	}
 
@@ -730,34 +770,21 @@ func validateMR(sourceBranch, targetBranch string) error {
 	return nil
 }
 
-func getExistingMR(client *http.Client, config *Config) (*MergeRequest, error) {
+func getExistingMR(ctx context.Context, client *http.Client, config *Config) (*MergeRequest, error) {
 	params := url.Values{}
 	params.Set("state", "opened")
 	params.Set("source_branch", config.SourceBranch)
 	params.Set("target_branch", config.TargetBranch)
 	params.Set("per_page", "1")
-	apiURL := fmt.Sprintf("%s/api/v4/projects/%d/merge_requests?%s",
-		config.GitLabURL, config.ProjectID, params.Encode())
 
-	req, err := http.NewRequest("GET", apiURL, http.NoBody)
+	body, err := doRequest(ctx, client, config, http.MethodGet,
+		fmt.Sprintf("projects/%d/merge_requests?%s", config.ProjectID, params.Encode()), nil)
 	if err != nil {
 		return nil, err
-	}
-
-	req.Header.Set("PRIVATE-TOKEN", config.PrivateToken)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
 	}
 
 	var mrs []MergeRequest
-	if err := json.NewDecoder(resp.Body).Decode(&mrs); err != nil {
+	if err := json.Unmarshal(body, &mrs); err != nil {
 		return nil, err
 	}
 
@@ -787,8 +814,6 @@ func getDescriptionData(descriptionPath string) string {
 		return ""
 	}
 
-	// #nosec G304 -- the path comes from the caller's own --description flag and the
-	// tool runs with the caller's rights, so there is no privilege boundary to cross.
 	data, err := os.ReadFile(descriptionPath)
 	if err != nil {
 		fmt.Printf("Unable to read description file at %s: %v. No description will be set.\n",
@@ -799,7 +824,7 @@ func getDescriptionData(descriptionPath string) string {
 	return string(data)
 }
 
-func getIssueData(client *http.Client, config *Config) (*Issue, error) {
+func getIssueData(ctx context.Context, client *http.Client, config *Config) (*Issue, error) {
 	re := regexp.MustCompile(`#(\d+)`)
 	matches := re.FindStringSubmatch(config.SourceBranch)
 	if len(matches) < 2 {
@@ -811,148 +836,84 @@ func getIssueData(client *http.Client, config *Config) (*Issue, error) {
 		return nil, fmt.Errorf("invalid issue number: %s", matches[1])
 	}
 
-	apiURL := fmt.Sprintf("%s/api/v4/projects/%d/issues/%d", config.GitLabURL, config.ProjectID, issueID)
-
-	req, err := http.NewRequest("GET", apiURL, http.NoBody)
+	body, err := doRequest(ctx, client, config, http.MethodGet,
+		fmt.Sprintf("projects/%d/issues/%d", config.ProjectID, issueID), nil)
 	if err != nil {
+		// Any answer from GitLab other than success means the issue is not
+		// usable here, whatever the status; transport errors pass through.
+		var apiErr *apiError
+		if errors.As(err, &apiErr) {
+			return nil, fmt.Errorf("issue #%d not found", issueID)
+		}
 		return nil, err
-	}
-
-	req.Header.Set("PRIVATE-TOKEN", config.PrivateToken)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("issue #%d not found", issueID)
 	}
 
 	var issue Issue
-	if err := json.NewDecoder(resp.Body).Decode(&issue); err != nil {
+	if err := json.Unmarshal(body, &issue); err != nil {
 		return nil, err
 	}
 
 	return &issue, nil
 }
 
-func createMR(client *http.Client, config *Config, mrRequest *MRCreateRequest) (*MergeRequest, error) {
-	apiURL := fmt.Sprintf("%s/api/v4/projects/%d/merge_requests", config.GitLabURL, config.ProjectID)
-
-	jsonData, err := json.Marshal(mrRequest)
+func createMR(
+	ctx context.Context, client *http.Client, config *Config, mrRequest *MRCreateRequest,
+) (*MergeRequest, error) {
+	body, err := doRequest(ctx, client, config, http.MethodPost,
+		fmt.Sprintf("projects/%d/merge_requests", config.ProjectID), mrRequest)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", apiURL, bytes.NewBuffer(jsonData))
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("PRIVATE-TOKEN", config.PrivateToken)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 201 {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
-	}
-
+	// GitLab always sends the created MR back, but an empty body is not a
+	// failure: the MR exists, only its IID is unknown.
 	var mr MergeRequest
-	if err := json.NewDecoder(resp.Body).Decode(&mr); err != nil {
-		if err == io.EOF {
-			return &mr, nil
-		}
+	if len(body) == 0 {
+		return &mr, nil
+	}
+
+	if err := json.Unmarshal(body, &mr); err != nil {
 		return nil, fmt.Errorf("MR created but response is invalid: %v", err)
 	}
 
 	return &mr, nil
 }
 
-func updateMR(client *http.Client, config *Config, mrIID int, updateRequest *MRUpdateRequest) error {
-	apiURL := fmt.Sprintf("%s/api/v4/projects/%d/merge_requests/%d", config.GitLabURL, config.ProjectID, mrIID)
-
-	jsonData, err := json.Marshal(updateRequest)
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest("PUT", apiURL, bytes.NewBuffer(jsonData))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("PRIVATE-TOKEN", config.PrivateToken)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
-	}
-
-	return nil
+func updateMR(
+	ctx context.Context, client *http.Client, config *Config, mrIID int, updateRequest *MRUpdateRequest,
+) error {
+	_, err := doRequest(ctx, client, config, http.MethodPut,
+		fmt.Sprintf("projects/%d/merge_requests/%d", config.ProjectID, mrIID), updateRequest)
+	return err
 }
 
-func acceptMR(client *http.Client, config *Config, mrIID int) error {
-	apiURL := fmt.Sprintf("%s/api/v4/projects/%d/merge_requests/%d/merge", config.GitLabURL, config.ProjectID, mrIID)
-
+func acceptMR(ctx context.Context, client *http.Client, config *Config, mrIID int) error {
 	acceptRequest := &MRAcceptRequest{
 		MergeWhenPipelineSucceeds: true,
 		ShouldRemoveSourceBranch:  config.RemoveBranch,
 		Squash:                    config.SquashCommits,
 	}
 
-	jsonData, err := json.Marshal(acceptRequest)
-	if err != nil {
-		return err
+	_, err := doRequest(ctx, client, config, http.MethodPut,
+		fmt.Sprintf("projects/%d/merge_requests/%d/merge", config.ProjectID, mrIID), acceptRequest)
+
+	var apiErr *apiError
+	if errors.As(err, &apiErr) {
+		switch apiErr.StatusCode {
+		case http.StatusMethodNotAllowed:
+			return fmt.Errorf(
+				"merge request cannot be merged, " +
+					"the pipeline may not have started yet or other merge conditions are not met",
+			)
+		case http.StatusNotAcceptable:
+			return fmt.Errorf(
+				"merge request cannot be merged, " +
+					"there may be unresolved discussions or other blocking conditions",
+			)
+		}
 	}
 
-	req, err := http.NewRequest("PUT", apiURL, bytes.NewBuffer(jsonData))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("PRIVATE-TOKEN", config.PrivateToken)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	switch resp.StatusCode {
-	case 200:
-		return nil
-	case 401:
-		return fmt.Errorf("unauthorized access, check your access token permissions")
-	case 405:
-		return fmt.Errorf(
-			"merge request cannot be merged, " +
-				"the pipeline may not have started yet or other merge conditions are not met",
-		)
-	case 406:
-		return fmt.Errorf(
-			"merge request cannot be merged, " +
-				"there may be unresolved discussions or other blocking conditions",
-		)
-	default:
-		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
-	}
+	return err
 }
 
 func versionInfo() string {

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -379,7 +380,7 @@ func TestGetProject(t *testing.T) {
 	}
 
 	// Test successful request
-	project, err := getProject(client, config)
+	project, err := getProject(context.Background(), client, config)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -395,7 +396,7 @@ func TestGetProject(t *testing.T) {
 
 	// Test unauthorized request
 	config.PrivateToken = ""
-	_, err = getProject(client, config)
+	_, err = getProject(context.Background(), client, config)
 	if err == nil {
 		t.Error("Expected error for unauthorized request")
 	}
@@ -457,7 +458,7 @@ func TestGetExistingMR(t *testing.T) {
 	}
 
 	// Test finding existing MR
-	mr, err := getExistingMR(client, config)
+	mr, err := getExistingMR(context.Background(), client, config)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -470,7 +471,7 @@ func TestGetExistingMR(t *testing.T) {
 
 	// Test not finding MR
 	config.SourceBranch = "feature/nonexistent"
-	mr, err = getExistingMR(client, config)
+	mr, err = getExistingMR(context.Background(), client, config)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -519,7 +520,7 @@ func TestGetExistingMRServerSideFiltering(t *testing.T) {
 		TargetBranch: "main",
 	}
 
-	mr, err := getExistingMR(client, config)
+	mr, err := getExistingMR(context.Background(), client, config)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -585,7 +586,7 @@ func TestGetExistingMRSpecialChars(t *testing.T) {
 		TargetBranch: targetBranch,
 	}
 
-	mr, err := getExistingMR(client, config)
+	mr, err := getExistingMR(context.Background(), client, config)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -632,7 +633,7 @@ func TestGetIssueData(t *testing.T) {
 	}
 
 	// Test successful request
-	issue, err := getIssueData(client, config)
+	issue, err := getIssueData(context.Background(), client, config)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -651,14 +652,14 @@ func TestGetIssueData(t *testing.T) {
 
 	// Test invalid branch name
 	config.SourceBranch = "feature/no-issue"
-	_, err = getIssueData(client, config)
+	_, err = getIssueData(context.Background(), client, config)
 	if err == nil {
 		t.Error("Expected error for invalid branch name")
 	}
 
 	// Test invalid issue number
 	config.SourceBranch = "feature/fix-#invalid"
-	_, err = getIssueData(client, config)
+	_, err = getIssueData(context.Background(), client, config)
 	if err == nil {
 		t.Error("Expected error for invalid issue number")
 	}
@@ -713,7 +714,7 @@ func TestCreateMR(t *testing.T) {
 		Description:  "Test description",
 	}
 
-	mr, err := createMR(client, config, mrRequest)
+	mr, err := createMR(context.Background(), client, config, mrRequest)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -729,7 +730,7 @@ func TestCreateMR(t *testing.T) {
 
 	// Test failed creation
 	mrRequest.SourceBranch = ""
-	_, err = createMR(client, config, mrRequest)
+	_, err = createMR(context.Background(), client, config, mrRequest)
 	if err == nil {
 		t.Error("Expected error for invalid request")
 	}
@@ -776,7 +777,7 @@ func TestUpdateMR(t *testing.T) {
 		Description: "Updated description",
 	}
 
-	err := updateMR(client, config, 1, updateRequest)
+	err := updateMR(context.Background(), client, config, 1, updateRequest)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -819,7 +820,7 @@ func TestRunCreateOnly(t *testing.T) {
 		SquashCommits: false,
 	}
 
-	err := run(config)
+	err := run(context.Background(), config)
 	if err != nil {
 		t.Errorf("Expected no error for create-only with no existing MR, got %v", err)
 	}
@@ -868,7 +869,7 @@ func TestRunUpdateOnly(t *testing.T) {
 		SquashCommits: false,
 	}
 
-	err := run(config)
+	err := run(context.Background(), config)
 	if err != nil {
 		t.Errorf("Expected no error for update-only with existing MR, got %v", err)
 	}
@@ -912,7 +913,7 @@ func TestRunMRExists(t *testing.T) {
 		MRExists:     true,
 	}
 
-	err := run(config)
+	err := run(context.Background(), config)
 	if err != nil {
 		t.Errorf("Expected no error for MR exists check, got %v", err)
 	}
@@ -929,7 +930,7 @@ func TestRunErrorCases(t *testing.T) {
 		UserIDs:      []int{1},
 	}
 
-	err := run(config)
+	err := run(context.Background(), config)
 	if err == nil {
 		t.Error("Expected error for same source and target branches")
 	}
@@ -970,7 +971,7 @@ func TestRunErrorCases(t *testing.T) {
 		CreateOnly:   true,
 	}
 
-	err = run(config)
+	err = run(context.Background(), config)
 	if err == nil {
 		t.Error("Expected error for create-only with existing MR")
 	}
@@ -1001,7 +1002,7 @@ func TestRunErrorCases(t *testing.T) {
 		UpdateMR:     true,
 	}
 
-	err = run(config)
+	err = run(context.Background(), config)
 	if err == nil {
 		t.Error("Expected error for update-only with no existing MR")
 	}
@@ -1061,13 +1062,13 @@ func TestErrorHandling(t *testing.T) {
 	}
 
 	// Test getProject error handling
-	_, err := getProject(client, config)
+	_, err := getProject(context.Background(), client, config)
 	if err == nil {
 		t.Error("Expected error for HTTP 500 response")
 	}
 
 	// Test getExistingMR error handling
-	_, err = getExistingMR(client, config)
+	_, err = getExistingMR(context.Background(), client, config)
 	if err == nil {
 		t.Error("Expected error for HTTP 500 response")
 	}
@@ -1118,7 +1119,7 @@ func TestRunExistingMRWithoutUpdateFlag(t *testing.T) {
 		SquashCommits: false,
 	}
 
-	err := run(config)
+	err := run(context.Background(), config)
 	if err != nil {
 		t.Errorf("Expected no error when MR exists without --update-mr flag, got %v", err)
 	}
@@ -1160,7 +1161,7 @@ func TestAcceptMR(t *testing.T) {
 		SquashCommits: true,
 	}
 
-	err := acceptMR(client, config, 42)
+	err := acceptMR(context.Background(), client, config, 42)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -1179,7 +1180,7 @@ func TestAcceptMR405(t *testing.T) {
 		PrivateToken: "test-token",
 	}
 
-	err := acceptMR(client, config, 42)
+	err := acceptMR(context.Background(), client, config, 42)
 	if err == nil {
 		t.Error("Expected error for 405 response")
 	}
@@ -1201,7 +1202,7 @@ func TestAcceptMR401(t *testing.T) {
 		PrivateToken: "bad-token",
 	}
 
-	err := acceptMR(client, config, 42)
+	err := acceptMR(context.Background(), client, config, 42)
 	if err == nil {
 		t.Error("Expected error for 401 response")
 	}
@@ -1223,7 +1224,7 @@ func TestAcceptMR406(t *testing.T) {
 		PrivateToken: "test-token",
 	}
 
-	err := acceptMR(client, config, 42)
+	err := acceptMR(context.Background(), client, config, 42)
 	if err == nil {
 		t.Error("Expected error for 406 response")
 	}
@@ -1263,7 +1264,7 @@ func TestAutoMergeWithDraftPrefixConflict(t *testing.T) {
 		CommitPrefix: "Draft",
 	}
 
-	err := run(config)
+	err := run(context.Background(), config)
 	if err == nil {
 		t.Error("Expected error for --auto-merge with draft prefix")
 	}
@@ -1273,7 +1274,7 @@ func TestAutoMergeWithDraftPrefixConflict(t *testing.T) {
 
 	// Also test with WIP prefix
 	config.CommitPrefix = "WIP"
-	err = run(config)
+	err = run(context.Background(), config)
 	if err == nil {
 		t.Error("Expected error for --auto-merge with WIP prefix")
 	}
@@ -1285,7 +1286,7 @@ func TestAutoMergeWithMRExistsConflict(t *testing.T) {
 		MRExists:  true,
 	}
 
-	err := run(config)
+	err := run(context.Background(), config)
 	if err == nil {
 		t.Error("Expected error for --auto-merge with --mr-exists")
 	}
@@ -1329,7 +1330,7 @@ func TestRunWithAutoMerge(t *testing.T) {
 		SquashCommits: false,
 	}
 
-	err := run(config)
+	err := run(context.Background(), config)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -1372,7 +1373,7 @@ func TestRunWithAutoMergeUpdate(t *testing.T) {
 		CommitPrefix: "",
 	}
 
-	err := run(config)
+	err := run(context.Background(), config)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -1395,7 +1396,7 @@ func TestCreateMREmptyResponseBody(t *testing.T) {
 		PrivateToken: "test-token",
 	}
 
-	mr, err := createMR(client, config, &MRCreateRequest{
+	mr, err := createMR(context.Background(), client, config, &MRCreateRequest{
 		SourceBranch: "feature/test",
 		TargetBranch: "main",
 		Title:        "Test MR",
@@ -1425,7 +1426,7 @@ func TestCreateMRInvalidResponseBody(t *testing.T) {
 		PrivateToken: "test-token",
 	}
 
-	_, err := createMR(client, config, &MRCreateRequest{
+	_, err := createMR(context.Background(), client, config, &MRCreateRequest{
 		SourceBranch: "feature/test",
 		TargetBranch: "main",
 		Title:        "Test MR",
@@ -1469,7 +1470,7 @@ func TestRunWithAutoMergeExistingMRNoUpdate(t *testing.T) {
 		CommitPrefix: "",
 	}
 
-	err := run(config)
+	err := run(context.Background(), config)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -1522,7 +1523,7 @@ func TestRunWithIssueData(t *testing.T) {
 		SquashCommits: false,
 	}
 
-	err := run(config)
+	err := run(context.Background(), config)
 	if err != nil {
 		t.Errorf("Expected no error for run with issue data, got %v", err)
 	}
@@ -1578,7 +1579,7 @@ func TestRunWithIssueDataError(t *testing.T) {
 		os.Stderr = origStderr
 	})
 
-	runErr := run(config)
+	runErr := run(context.Background(), config)
 
 	if cerr := wPipe.Close(); cerr != nil {
 		t.Fatalf("Failed to close stderr pipe: %v", cerr)
@@ -1767,7 +1768,7 @@ func TestRunLabelAndMilestone(t *testing.T) {
 				UseIssueName: tt.useIssueName,
 			}
 
-			if err := run(config); err != nil {
+			if err := run(context.Background(), config); err != nil {
 				t.Fatalf("run() error = %v", err)
 			}
 
@@ -1906,7 +1907,7 @@ func TestPrintMRURL(t *testing.T) {
 			}
 
 			var runErr error
-			out := captureOutput(t, func() { runErr = run(config) })
+			out := captureOutput(t, func() { runErr = run(context.Background(), config) })
 			if runErr != nil {
 				t.Fatalf("run() error = %v", runErr)
 			}
@@ -2030,7 +2031,7 @@ func TestTriggerMRPipelineDeduplicates(t *testing.T) {
 				ForcePipeline:   tt.force,
 			}
 
-			err := triggerMRPipeline(server.Client(), config, &MergeRequest{IID: 42, SHA: tt.mrSHA})
+			err := triggerMRPipeline(context.Background(), server.Client(), config, &MergeRequest{IID: 42, SHA: tt.mrSHA})
 			if err != nil {
 				t.Fatalf("triggerMRPipeline() error = %v", err)
 			}
@@ -2088,7 +2089,7 @@ func TestRunTriggersPipelineOnUpdate(t *testing.T) {
 		TriggerPipeline: true,
 	}
 
-	if err := run(config); err != nil {
+	if err := run(context.Background(), config); err != nil {
 		t.Fatalf("run() error = %v", err)
 	}
 	if created != 1 {
@@ -2122,6 +2123,162 @@ func TestShortSHA(t *testing.T) {
 				t.Errorf("shortSHA(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestAPIErrorMessage pins the wording apiError produces, since it is what
+// every API function reports for an unexpected status.
+func TestAPIErrorMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *apiError
+		want string
+	}{
+		{"with body", &apiError{StatusCode: 400, Body: "bad request"}, "HTTP 400: bad request"},
+		{"empty body", &apiError{StatusCode: 500}, "HTTP 500"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.want {
+				t.Errorf("Error() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDoRequestUnauthorized checks that a 401 from any endpoint produces the
+// single shared errUnauthorized, so callers can match it with errors.Is.
+func TestDoRequestUnauthorized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	config := &Config{PrivateToken: "bad", ProjectID: 123, GitLabURL: server.URL}
+
+	_, err := doRequest(context.Background(), server.Client(), config, http.MethodGet, "projects/123", nil)
+	if !errors.Is(err, errUnauthorized) {
+		t.Errorf("expected errUnauthorized, got %v", err)
+	}
+}
+
+// TestDoRequestSendsTokenAndBody checks the three things the helper is
+// responsible for on the way out: the URL, the token header, and the JSON body
+// with its Content-Type. A GET must send neither body nor Content-Type.
+func TestDoRequestSendsTokenAndBody(t *testing.T) {
+	var (
+		gotPath        string
+		gotToken       string
+		gotContentType string
+		gotBody        string
+		gotMethod      string
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotToken = r.Header.Get("PRIVATE-TOKEN")
+		gotContentType = r.Header.Get("Content-Type")
+		gotMethod = r.Method
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		gotBody = string(body)
+		if _, err := w.Write([]byte(`{"ok":true}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	config := &Config{PrivateToken: "test-token", ProjectID: 123, GitLabURL: server.URL}
+
+	t.Run("post with body", func(t *testing.T) {
+		resp, err := doRequest(context.Background(), server.Client(), config,
+			http.MethodPost, "projects/123/merge_requests", map[string]string{"title": "x"})
+		if err != nil {
+			t.Fatalf("doRequest() error = %v", err)
+		}
+		if string(resp) != `{"ok":true}` {
+			t.Errorf("body = %q, want %q", string(resp), `{"ok":true}`)
+		}
+		if gotMethod != http.MethodPost {
+			t.Errorf("method = %q, want POST", gotMethod)
+		}
+		if gotPath != "/api/v4/projects/123/merge_requests" {
+			t.Errorf("path = %q", gotPath)
+		}
+		if gotToken != "test-token" {
+			t.Errorf("PRIVATE-TOKEN = %q, want %q", gotToken, "test-token")
+		}
+		if gotContentType != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", gotContentType)
+		}
+		if gotBody != `{"title":"x"}` {
+			t.Errorf("request body = %q, want %q", gotBody, `{"title":"x"}`)
+		}
+	})
+
+	t.Run("get without body", func(t *testing.T) {
+		if _, err := doRequest(context.Background(), server.Client(), config,
+			http.MethodGet, "projects/123", nil); err != nil {
+			t.Fatalf("doRequest() error = %v", err)
+		}
+		if gotBody != "" {
+			t.Errorf("GET sent a body: %q", gotBody)
+		}
+		if gotContentType != "" {
+			t.Errorf("GET sent Content-Type: %q", gotContentType)
+		}
+	})
+}
+
+// TestRunContextCancellation covers issue #69: a canceled context aborts the
+// request in flight rather than waiting out the client timeout.
+func TestRunContextCancellation(t *testing.T) {
+	released := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Hold the response until the client gives up on it.
+		select {
+		case <-released:
+		case <-r.Context().Done():
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer func() {
+		close(released)
+		server.Close()
+	}()
+
+	config := &Config{
+		PrivateToken: "test-token",
+		SourceBranch: "feature/test",
+		ProjectID:    123,
+		GitLabURL:    server.URL,
+		UserIDs:      []int{1},
+		TargetBranch: "main",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := run(ctx, config)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from the canceled request, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	// The client timeout is 30s; returning anywhere near it means cancellation
+	// was ignored.
+	if elapsed > 5*time.Second {
+		t.Errorf("run() took %v, expected it to abort as soon as the context was canceled", elapsed)
 	}
 }
 
@@ -2460,7 +2617,7 @@ func TestTriggerMRPipeline(t *testing.T) {
 		PrivateToken: "test-token",
 	}
 
-	if err := triggerMRPipeline(client, config, &MergeRequest{IID: 42}); err != nil {
+	if err := triggerMRPipeline(context.Background(), client, config, &MergeRequest{IID: 42}); err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
 }
@@ -2479,7 +2636,7 @@ func TestTriggerMRPipelineZeroIID(t *testing.T) {
 		PrivateToken: "test-token",
 	}
 
-	if err := triggerMRPipeline(client, config, &MergeRequest{}); err != nil {
+	if err := triggerMRPipeline(context.Background(), client, config, &MergeRequest{}); err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
 }
@@ -2512,7 +2669,7 @@ func TestTriggerMRPipelineErrors(t *testing.T) {
 				PrivateToken: "test-token",
 			}
 
-			err := triggerMRPipeline(client, config, &MergeRequest{IID: 42})
+			err := triggerMRPipeline(context.Background(), client, config, &MergeRequest{IID: 42})
 			if err == nil {
 				t.Fatal("Expected an error, got nil")
 			}
@@ -2539,7 +2696,7 @@ func TestTriggerMRPipelineUnreadableBody(t *testing.T) {
 		PrivateToken: "test-token",
 	}
 
-	if err := triggerMRPipeline(client, config, &MergeRequest{IID: 42}); err != nil {
+	if err := triggerMRPipeline(context.Background(), client, config, &MergeRequest{IID: 42}); err != nil {
 		t.Errorf("Expected no error for an unreadable body, got %v", err)
 	}
 }
@@ -2585,7 +2742,7 @@ func TestRunWithTriggerPipeline(t *testing.T) {
 		AutoMerge:       true,
 	}
 
-	if err := run(config); err != nil {
+	if err := run(context.Background(), config); err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
@@ -2629,7 +2786,7 @@ func TestRunWithoutTriggerPipeline(t *testing.T) {
 		UserIDs:      []int{1},
 	}
 
-	if err := run(config); err != nil {
+	if err := run(context.Background(), config); err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
 }


### PR DESCRIPTION
Closes #144, closes #69. The two go together: the helper is where `http.NewRequestWithContext` belongs, and doing them separately would mean touching all seven API functions twice.

Rebased onto `main` after #143 landed, so `triggerMRPipeline` — the function the issue cites as the one that made the duplication concrete — is converted along with the rest.

## The helper

Every API function repeated the same five steps — build URL, `http.NewRequest`, set `PRIVATE-TOKEN` (and sometimes `Content-Type`), `Do` + `defer Close`, `switch resp.StatusCode` ending in `HTTP %d: %s`. That is now:

```go
func doRequest(ctx context.Context, client *http.Client, config *Config,
	method, path string, body any) ([]byte, error)
```

`path` is relative to `/api/v4`; `body` is marshalled as JSON when non-nil (and only then is `Content-Type` set). Any 2xx is success.

**Decoding stays with the callers.** The helper returns raw bytes rather than taking an `out any`, because each caller has its own wording for a malformed body — `createMR` reports "MR created but response is invalid", `triggerMRPipeline` warns and carries on because the pipeline already exists by then, and an empty body from `createMR` is not a failure at all. The bodies are single objects, and the old code already read them whole to build error messages.

**Endpoint-specific statuses stay with the callers too**, as the issue asked. Unexpected statuses come back as `*apiError` carrying code and body, so `acceptMR` still matches 405/406 and `triggerMRPipeline` still matches 400/403, both via `errors.As`. `getIssueData` still turns any GitLab answer into `issue #N not found` while letting transport errors through unchanged.

**401 is the exception** — it means the same thing on every endpoint, so it is now one `errUnauthorized` instead of three different sentences across `getProject`, `acceptMR` and `triggerMRPipeline`. The wording gained "and has the api scope", since a token that lacks the scope produces this exact error; the README's troubleshooting sample is updated to match.

## Context

`main()` builds the context with `signal.NotifyContext(…, os.Interrupt, syscall.SIGTERM)`, so Ctrl-C or a cancelled CI job aborts the in-flight request instead of sitting out the 30-second client timeout. `stop()` is called directly rather than deferred — `os.Exit` on the error path would skip a defer, which `gocritic` correctly flags.

`run()` gained a `ctx` parameter (all test call sites updated), and its wrapping moved from `%v` to `%w` so `errors.Is` reaches the cause. That is what lets the cancellation test assert on `context.Canceled` rather than on a substring.

## Tests

- `TestAPIErrorMessage` — pins `HTTP 400: body` and the bodyless `HTTP 500`.
- `TestDoRequestUnauthorized` — a 401 matches `errors.Is(err, errUnauthorized)`.
- `TestDoRequestSendsTokenAndBody` — path, method, token header, JSON body and `Content-Type` on a POST; and that a GET sends neither body nor `Content-Type`.
- `TestRunContextCancellation` — against a server that holds the response, cancelling the context returns `context.Canceled` promptly rather than after the client timeout.

The existing suite, including the `triggerMRPipeline` tests from #143, passes unchanged apart from the added `ctx` argument.

```
$ go test -race ./...
ok  	gitlab-auto-mr	1.923s
$ golangci-lint run
0 issues.
```