### PR TITLE
chore: ignore the hyphenated binary name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 *.dylib
 gitlab_auto_mr
 gitlab_auto_mr-*
+# `go build -o gitlab-auto-mr` and goreleaser's project name both produce the
+# hyphenated spelling, which the two lines above do not cover.
+gitlab-auto-mr
+gitlab-auto-mr-*
 
 # Test files
 *.test


### PR DESCRIPTION
`.gitignore` covers `gitlab_auto_mr` (underscored) but not `gitlab-auto-mr` (hyphenated) — which is the name `goreleaser` uses as its `project_name`, and the one you get from a plain `go build -o gitlab-auto-mr`.

The result is an 8.6 MB build artifact permanently visible in `git status` as untracked, one `git add -A` away from being committed. I hit exactly that while working on the other PRs in this batch and had to rewrite five branches to get it back out — which is the practical argument for the two lines.

Same class of problem as #71.