### PR TITLE
feat: retry transient GitLab failures, make the timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ create_only:
 - `CI_PROJECT_URL` - GitLab URL
 - `CI_COMMIT_REF_NAME` - Source branch name
 
+### Optional Environment Variables
+
+- `GITLAB_AUTO_MR_TIMEOUT` - Timeout for a single API request (default `30s`)
+- `GITLAB_AUTO_MR_RETRIES` - Retries for transient failures (default `2`)
+- `GITLAB_AUTO_MR_RETRY_DELAY` - Delay before the first retry (default `1s`)
+
 ### CLI Options
 
 | Option                  | Short | Description                                    | Default                |
@@ -156,6 +162,9 @@ create_only:
 | `--create-only`         |       | Force create new MR (fail if already exists)   | `false`                |
 | `--auto-merge`          |       | Enable merge when pipeline succeeds (auto-merge) | `false`              |
 | `--trigger-pipeline`    |       | Create a merge request pipeline after the MR is created | `false`         |
+| `--timeout`             |       | Timeout for a single API request               | `30s`                  |
+| `--retries`             |       | Retries for transient failures (5xx, 429, network) | `2`                |
+| `--retry-delay`         |       | Delay before the first retry, doubled each time | `1s`                  |
 | `--insecure`            | `-k`  | Skip SSL certificate verification              | `false`                |
 
 ### Merge Request Pipelines
@@ -187,6 +196,28 @@ Two things to expect:
   role on the project. A `CI_JOB_TOKEN` cannot be used: the Merge Requests API
   is read-only for job tokens, so it can neither create the MR nor request a
   pipeline for it.
+
+## Retries
+
+Self-hosted GitLab returns 502/503 during restarts and upgrades, and CI runners
+hit transient network errors. By default the tool retries such a failure twice,
+waiting 1s and then 2s, so a job does not fail for a reason that a re-run would
+have fixed anyway. `--retries 0` turns it off.
+
+What gets retried depends on what a repeat could do:
+
+| Request | Retried on 5xx / 429 | Retried on a network error |
+| --- | --- | --- |
+| `GET`, `PUT` | yes | yes |
+| `POST` | no | only if the connection was never established |
+
+`POST /merge_requests` is the reason for the asymmetry: retrying it after a
+timeout could open a second merge request. A failure to dial is safe to repeat,
+because the request demonstrably never reached GitLab.
+
+A `Retry-After` header — which GitLab sends when rate limiting — takes
+precedence over the backoff, capped at 30s. 4xx answers other than 429 are never
+retried: they are real answers, and repeating them only delays the error.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ docker build -t gitlab-auto-mr .
 **Authentication Error**
 
 ```
-Error: unable to get project 12345: unauthorized access, check your access token is valid
+Error: unable to get project 12345: unauthorized access, check your access token is valid and has the api scope
 ```
 
 - Check your `GITLAB_PRIVATE_TOKEN` is valid and has `api` scope

--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ What gets retried depends on what a repeat could do:
 timeout could open a second merge request. A failure to dial is safe to repeat,
 because the request demonstrably never reached GitLab.
 
+A request that outran `--timeout` counts as a network error here, so a hung GET
+is retried. Ctrl-C is not: once the caller has given up, nothing is retried.
+
 A `Retry-After` header — which GitLab sends when rate limiting — takes
 precedence over the backoff, capped at 30s. 4xx answers other than 429 are never
 retried: they are real answers, and repeating them only delays the error.

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -32,6 +33,15 @@ var (
 const (
 	draftPrefix = "draft"
 	wipPrefix   = "wip"
+)
+
+// Defaults for the HTTP behavior. They are applied where they are used, not
+// only in parseFlags, so a zero-valued Config still behaves like the tool did
+// before these flags existed.
+const (
+	defaultTimeout    = 30 * time.Second
+	defaultRetryDelay = time.Second
+	maxRetryDelay     = 30 * time.Second
 )
 
 // errShowVersion is a sentinel error returned by parseFlags when --version has
@@ -60,6 +70,9 @@ type Config struct {
 	CreateOnly         bool
 	AutoMerge          bool
 	TriggerPipeline    bool
+	Timeout            time.Duration
+	Retries            int
+	RetryDelay         time.Duration
 }
 
 type Project struct {
@@ -183,6 +196,13 @@ func parseFlags() (*Config, error) {
 	flag.BoolVar(&config.AutoMerge, "auto-merge", false, "Enable merge when pipeline succeeds (auto-merge)")
 	flag.BoolVar(&config.TriggerPipeline, "trigger-pipeline", false,
 		"Create a merge request pipeline after the MR is created")
+	flag.DurationVar(&config.Timeout, "timeout", getEnvDuration("GITLAB_AUTO_MR_TIMEOUT", defaultTimeout),
+		"Timeout for a single GitLab API request")
+	flag.IntVar(&config.Retries, "retries", getEnvInt("GITLAB_AUTO_MR_RETRIES", 2),
+		"Retries for transient GitLab failures (network errors, 5xx, 429)")
+	flag.DurationVar(&config.RetryDelay, "retry-delay",
+		getEnvDuration("GITLAB_AUTO_MR_RETRY_DELAY", defaultRetryDelay),
+		"Delay before the first retry, doubled on each further attempt")
 	flag.BoolVar(&showVersion, "version", false, "Show version information and exit")
 	flag.BoolVar(&showVersion, "v", false, "Show version information and exit (short)")
 
@@ -208,6 +228,16 @@ func parseFlags() (*Config, error) {
 	}
 	if userIDsStr == "" {
 		return nil, fmt.Errorf("--user-id is required")
+	}
+
+	if config.Timeout <= 0 {
+		return nil, fmt.Errorf("--timeout must be positive, got %s", config.Timeout)
+	}
+	if config.Retries < 0 {
+		return nil, fmt.Errorf("--retries must not be negative, got %d", config.Retries)
+	}
+	if config.RetryDelay < 0 {
+		return nil, fmt.Errorf("--retry-delay must not be negative, got %s", config.RetryDelay)
 	}
 
 	// Parse user IDs
@@ -266,7 +296,7 @@ func run(ctx context.Context, config *Config) error {
 		return err
 	}
 
-	client := createHTTPClient(config.Insecure)
+	client := createHTTPClient(config)
 
 	project, err := getProject(ctx, client, config)
 	if err != nil {
@@ -493,12 +523,17 @@ func triggerMRPipeline(ctx context.Context, client *http.Client, config *Config,
 	return nil
 }
 
-func createHTTPClient(insecure bool) *http.Client {
-	client := &http.Client{
-		Timeout: 30 * time.Second,
+func createHTTPClient(config *Config) *http.Client {
+	timeout := config.Timeout
+	if timeout <= 0 {
+		timeout = defaultTimeout
 	}
 
-	if insecure {
+	client := &http.Client{
+		Timeout: timeout,
+	}
+
+	if config.Insecure {
 		tr := &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // user-requested via --insecure flag
 		}
@@ -530,7 +565,8 @@ func (e *apiError) Error() string {
 // re-worded per function.
 var errUnauthorized = errors.New("unauthorized access, check your access token is valid and has the api scope")
 
-// doRequest performs one GitLab API call and returns the raw response body.
+// doRequest performs one GitLab API call and returns the raw response body,
+// retrying the attempt when the failure looks transient.
 //
 // path is relative to /api/v4 and must already be escaped. body, when non-nil,
 // is sent as JSON. Any 2xx is success; 401 yields errUnauthorized and every
@@ -544,45 +580,172 @@ func doRequest(
 ) ([]byte, error) {
 	apiURL := fmt.Sprintf("%s/api/v4/%s", config.GitLabURL, path)
 
-	var reader io.Reader = http.NoBody
+	var jsonData []byte
 	if body != nil {
-		jsonData, err := json.Marshal(body)
-		if err != nil {
+		var err error
+		if jsonData, err = json.Marshal(body); err != nil {
 			return nil, err
 		}
-		reader = bytes.NewBuffer(jsonData)
+	}
+
+	for attempt := 0; ; attempt++ {
+		respBody, retryAfter, err := sendRequest(ctx, client, config, method, apiURL, jsonData, body != nil)
+		if err == nil {
+			return respBody, nil
+		}
+
+		if attempt >= config.Retries || !isRetryable(method, err) {
+			return nil, err
+		}
+
+		delay := retryDelay(config, attempt, retryAfter)
+		fmt.Fprintf(os.Stderr, "Warning: %s %s failed (%v), retrying in %s (%d/%d)\n",
+			method, path, err, delay, attempt+1, config.Retries)
+
+		if err := sleep(ctx, delay); err != nil {
+			return nil, err
+		}
+	}
+}
+
+// sendRequest performs a single attempt. The returned duration is the value of
+// a Retry-After header, when GitLab sent one that could be parsed.
+func sendRequest(
+	ctx context.Context, client *http.Client, config *Config,
+	method, apiURL string, jsonData []byte, hasBody bool,
+) ([]byte, time.Duration, error) {
+	var reader io.Reader = http.NoBody
+	if hasBody {
+		reader = bytes.NewReader(jsonData)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, method, apiURL, reader)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	req.Header.Set("PRIVATE-TOKEN", config.PrivateToken)
-	if body != nil {
+	if hasBody {
 		req.Header.Set("Content-Type", "application/json")
 	}
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	defer resp.Body.Close()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, errUnauthorized
+		return nil, 0, errUnauthorized
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, &apiError{StatusCode: resp.StatusCode, Body: string(respBody)}
+		return nil, parseRetryAfter(resp.Header.Get("Retry-After")),
+			&apiError{StatusCode: resp.StatusCode, Body: string(respBody)}
 	}
 
-	return respBody, nil
+	return respBody, 0, nil
+}
+
+// isRetryable decides whether a failed attempt is worth repeating.
+//
+// The rule is about what a repeat could do, not only about what failed. GET and
+// PUT are idempotent, so repeating one is harmless: at worst GitLab applies the
+// same change twice. POST is not — retrying POST /merge_requests after a
+// timeout could open a second MR — so it is repeated only when the request
+// demonstrably never reached GitLab, which is what a dial failure means.
+func isRetryable(method string, err error) bool {
+	if errors.Is(err, errUnauthorized) || errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	var apiErr *apiError
+	if errors.As(err, &apiErr) {
+		// GitLab answered, so the request did reach it: repeating is only safe
+		// for the idempotent verbs.
+		if !isIdempotent(method) {
+			return false
+		}
+		return apiErr.StatusCode >= 500 || apiErr.StatusCode == http.StatusTooManyRequests
+	}
+
+	if isIdempotent(method) {
+		return true
+	}
+
+	return isDialError(err)
+}
+
+func isIdempotent(method string) bool {
+	return method == http.MethodGet || method == http.MethodPut || method == http.MethodHead
+}
+
+// isDialError reports whether the connection was never established, which means
+// the server cannot have seen the request.
+func isDialError(err error) bool {
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return opErr.Op == "dial"
+	}
+	return false
+}
+
+// retryDelay is the exponential backoff, unless GitLab asked for a specific
+// wait via Retry-After — it knows better, and ignoring it on a 429 only earns
+// another one.
+func retryDelay(config *Config, attempt int, retryAfter time.Duration) time.Duration {
+	if retryAfter > 0 {
+		if retryAfter > maxRetryDelay {
+			return maxRetryDelay
+		}
+		return retryAfter
+	}
+
+	base := config.RetryDelay
+	if base <= 0 {
+		base = defaultRetryDelay
+	}
+
+	delay := base << attempt
+	// Shifting past the width of the type wraps; both cases mean "too long".
+	if delay > maxRetryDelay || delay <= 0 {
+		return maxRetryDelay
+	}
+	return delay
+}
+
+// parseRetryAfter reads the delay-seconds form of Retry-After, which is what
+// GitLab sends. The HTTP-date form is ignored rather than guessed at.
+func parseRetryAfter(value string) time.Duration {
+	if value == "" {
+		return 0
+	}
+
+	seconds, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || seconds < 0 {
+		return 0
+	}
+
+	return time.Duration(seconds) * time.Second
+}
+
+// sleep waits for d, or returns early if the context is canceled first.
+func sleep(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func getProject(ctx context.Context, client *http.Client, config *Config) (*Project, error) {
@@ -761,6 +924,15 @@ func versionInfo() string {
 func getEnv(key, defaultValue string) string {
 	if value := os.Getenv(key); value != "" {
 		return value
+	}
+	return defaultValue
+}
+
+func getEnvDuration(key string, defaultValue time.Duration) time.Duration {
+	if value := os.Getenv(key); value != "" {
+		if d, err := time.ParseDuration(value); err == nil {
+			return d
+		}
 	}
 	return defaultValue
 }

--- a/main.go
+++ b/main.go
@@ -594,7 +594,7 @@ func doRequest(
 			return respBody, nil
 		}
 
-		if attempt >= config.Retries || !isRetryable(method, err) {
+		if attempt >= config.Retries || !isRetryable(ctx, method, err) {
 			return nil, err
 		}
 
@@ -659,9 +659,16 @@ func sendRequest(
 // same change twice. POST is not — retrying POST /merge_requests after a
 // timeout could open a second MR — so it is repeated only when the request
 // demonstrably never reached GitLab, which is what a dial failure means.
-func isRetryable(method string, err error) bool {
-	if errors.Is(err, errUnauthorized) || errors.Is(err, context.Canceled) ||
-		errors.Is(err, context.DeadlineExceeded) {
+//
+// Whether the caller gave up is read from ctx, not from err. A --timeout that
+// elapsed also surfaces as context.DeadlineExceeded, and that one is a
+// transient failure worth repeating — the very case retries exist for.
+func isRetryable(ctx context.Context, method string, err error) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+
+	if errors.Is(err, errUnauthorized) {
 		return false
 	}
 

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -11,9 +12,11 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/signal"
 	"regexp"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -132,8 +135,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := run(config); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+	// Canceling on SIGINT/SIGTERM aborts the in-flight request instead of
+	// leaving the process to sit out the client timeout. stop() is called
+	// directly rather than deferred, since os.Exit below would skip a defer.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	runErr := run(ctx, config)
+	stop()
+
+	if runErr != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", runErr)
 		os.Exit(1)
 	}
 }
@@ -251,16 +261,16 @@ func checkMRExists(config *Config, existingMR *MergeRequest) {
 	}
 }
 
-func run(config *Config) error {
+func run(ctx context.Context, config *Config) error {
 	if err := validateConfig(config); err != nil {
 		return err
 	}
 
 	client := createHTTPClient(config.Insecure)
 
-	project, err := getProject(client, config)
+	project, err := getProject(ctx, client, config)
 	if err != nil {
-		return fmt.Errorf("unable to get project %d: %v", config.ProjectID, err)
+		return fmt.Errorf("unable to get project %d: %w", config.ProjectID, err)
 	}
 
 	if config.TargetBranch == "" {
@@ -271,9 +281,9 @@ func run(config *Config) error {
 		return err
 	}
 
-	existingMR, err := getExistingMR(client, config)
+	existingMR, err := getExistingMR(ctx, client, config)
 	if err != nil {
-		return fmt.Errorf("failed to check if MR exists: %v", err)
+		return fmt.Errorf("failed to check if MR exists: %w", err)
 	}
 
 	if config.MRExists {
@@ -300,26 +310,26 @@ func run(config *Config) error {
 	title := getMRTitle(config.CommitPrefix, config.Title, config.SourceBranch)
 	description := getDescriptionData(config.Description)
 
-	mrIID, err := handleMR(client, config, existingMR, title, description)
+	mrIID, err := handleMR(ctx, client, config, existingMR, title, description)
 	if err != nil {
 		return err
 	}
 
 	if config.TriggerPipeline {
-		if err := triggerMRPipeline(client, config, mrIID); err != nil {
-			return fmt.Errorf("failed to trigger merge request pipeline: %v", err)
+		if err := triggerMRPipeline(ctx, client, config, mrIID); err != nil {
+			return fmt.Errorf("failed to trigger merge request pipeline: %w", err)
 		}
 	}
 
 	if config.AutoMerge {
-		return enableAutoMerge(client, config, mrIID)
+		return enableAutoMerge(ctx, client, config, mrIID)
 	}
 
 	return nil
 }
 
 func handleMR(
-	client *http.Client, config *Config,
+	ctx context.Context, client *http.Client, config *Config,
 	existingMR *MergeRequest, title, description string,
 ) (int, error) {
 	switch {
@@ -339,15 +349,15 @@ func handleMR(
 		return existingMR.IID, nil
 
 	case existingMR != nil:
-		return handleUpdateMR(client, config, existingMR, title, description)
+		return handleUpdateMR(ctx, client, config, existingMR, title, description)
 
 	default:
-		return handleCreateMR(client, config, title, description)
+		return handleCreateMR(ctx, client, config, title, description)
 	}
 }
 
 func handleUpdateMR(
-	client *http.Client, config *Config,
+	ctx context.Context, client *http.Client, config *Config,
 	existingMR *MergeRequest, title, description string,
 ) (int, error) {
 	updateRequest := &MRUpdateRequest{
@@ -361,7 +371,7 @@ func handleUpdateMR(
 	}
 
 	if config.UseIssueName {
-		issueData, err := getIssueData(client, config)
+		issueData, err := getIssueData(ctx, client, config)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to fetch issue data: %v\n", err)
 		} else {
@@ -370,8 +380,8 @@ func handleUpdateMR(
 		}
 	}
 
-	if err := updateMR(client, config, existingMR.IID, updateRequest); err != nil {
-		return 0, fmt.Errorf("failed to update MR: %v", err)
+	if err := updateMR(ctx, client, config, existingMR.IID, updateRequest); err != nil {
+		return 0, fmt.Errorf("failed to update MR: %w", err)
 	}
 
 	fmt.Printf("Updated existing MR %s (IID: %d)\n", title, existingMR.IID)
@@ -379,7 +389,7 @@ func handleUpdateMR(
 }
 
 func handleCreateMR(
-	client *http.Client, config *Config,
+	ctx context.Context, client *http.Client, config *Config,
 	title, description string,
 ) (int, error) {
 	mrRequest := &MRCreateRequest{
@@ -395,7 +405,7 @@ func handleCreateMR(
 	}
 
 	if config.UseIssueName {
-		issueData, err := getIssueData(client, config)
+		issueData, err := getIssueData(ctx, client, config)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to fetch issue data: %v\n", err)
 		} else {
@@ -404,23 +414,23 @@ func handleCreateMR(
 		}
 	}
 
-	createdMR, err := createMR(client, config, mrRequest)
+	createdMR, err := createMR(ctx, client, config, mrRequest)
 	if err != nil {
-		return 0, fmt.Errorf("failed to create MR: %v", err)
+		return 0, fmt.Errorf("failed to create MR: %w", err)
 	}
 
 	fmt.Printf("Created a new MR %s, assigned to you.\n", title)
 	return createdMR.IID, nil
 }
 
-func enableAutoMerge(client *http.Client, config *Config, mrIID int) error {
+func enableAutoMerge(ctx context.Context, client *http.Client, config *Config, mrIID int) error {
 	if mrIID == 0 {
 		fmt.Println("Warning: could not determine MR IID, skipping auto-merge")
 		return nil
 	}
 
-	if err := acceptMR(client, config, mrIID); err != nil {
-		return fmt.Errorf("failed to enable auto-merge: %v", err)
+	if err := acceptMR(ctx, client, config, mrIID); err != nil {
+		return fmt.Errorf("failed to enable auto-merge: %w", err)
 	}
 
 	fmt.Printf("Auto-merge enabled for MR (IID: %d)\n", mrIID)
@@ -434,67 +444,53 @@ func enableAutoMerge(client *http.Client, config *Config, mrIID int) error {
 // for a commit that already has a branch pipeline. A CI configuration whose
 // jobs run only on `merge_request_event` would therefore never see the MR, and
 // the missing checks are easy to mistake for passing ones.
-func triggerMRPipeline(client *http.Client, config *Config, mrIID int) error {
+func triggerMRPipeline(ctx context.Context, client *http.Client, config *Config, mrIID int) error {
 	if mrIID == 0 {
 		fmt.Println("Warning: could not determine MR IID, skipping pipeline trigger")
 		return nil
 	}
 
-	apiURL := fmt.Sprintf(
-		"%s/api/v4/projects/%d/merge_requests/%d/pipelines",
-		config.GitLabURL, config.ProjectID, mrIID,
-	)
-
-	req, err := http.NewRequest("POST", apiURL, http.NoBody)
+	body, err := doRequest(ctx, client, config, http.MethodPost,
+		fmt.Sprintf("projects/%d/merge_requests/%d/pipelines", config.ProjectID, mrIID), nil)
 	if err != nil {
+		var apiErr *apiError
+		if errors.As(err, &apiErr) {
+			switch apiErr.StatusCode {
+			case http.StatusForbidden:
+				return fmt.Errorf(
+					"forbidden, the token owner needs at least the Developer role on the project " +
+						"to create pipelines",
+				)
+			case http.StatusBadRequest:
+				return fmt.Errorf(
+					"GitLab refused to create the pipeline, "+
+						"the CI configuration may define no jobs for merge request pipelines: %s",
+					apiErr.Body,
+				)
+			}
+		}
 		return err
 	}
 
-	req.Header.Set("PRIVATE-TOKEN", config.PrivateToken)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	switch resp.StatusCode {
-	case 200, 201:
-		// The pipeline already exists at this point, so a response we cannot read
-		// is worth a warning but must not fail the run: the body is only used to
-		// tell the user what was created.
-		var pipeline Pipeline
-		if err := json.NewDecoder(resp.Body).Decode(&pipeline); err != nil {
-			fmt.Printf("Warning: merge request pipeline created but response could not be read: %v\n", err)
-			return nil
-		}
-		if pipeline.WebURL != "" {
-			fmt.Printf(
-				"Merge request pipeline created (ID: %d, status: %s): %s\n",
-				pipeline.ID, pipeline.Status, pipeline.WebURL,
-			)
-			return nil
-		}
-		fmt.Printf("Merge request pipeline created (ID: %d, status: %s)\n", pipeline.ID, pipeline.Status)
+	// The pipeline already exists at this point, so a response we cannot read is
+	// worth a warning but must not fail the run: the body is only used to tell
+	// the user what was created.
+	var pipeline Pipeline
+	if err := json.Unmarshal(body, &pipeline); err != nil {
+		fmt.Printf("Warning: merge request pipeline created but response could not be read: %v\n", err)
 		return nil
-	case 401:
-		return fmt.Errorf("unauthorized access, check your access token permissions")
-	case 403:
-		return fmt.Errorf(
-			"forbidden, the token owner needs at least the Developer role on the project " +
-				"to create pipelines",
-		)
-	case 400:
-		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf(
-			"GitLab refused to create the pipeline, "+
-				"the CI configuration may define no jobs for merge request pipelines: %s",
-			string(respBody),
-		)
-	default:
-		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
 	}
+
+	if pipeline.WebURL != "" {
+		fmt.Printf(
+			"Merge request pipeline created (ID: %d, status: %s): %s\n",
+			pipeline.ID, pipeline.Status, pipeline.WebURL,
+		)
+		return nil
+	}
+
+	fmt.Printf("Merge request pipeline created (ID: %d, status: %s)\n", pipeline.ID, pipeline.Status)
+	return nil
 }
 
 func createHTTPClient(insecure bool) *http.Client {
@@ -512,15 +508,60 @@ func createHTTPClient(insecure bool) *http.Client {
 	return client
 }
 
-func getProject(client *http.Client, config *Config) (*Project, error) {
-	apiURL := fmt.Sprintf("%s/api/v4/projects/%d", config.GitLabURL, config.ProjectID)
+// apiError is returned by doRequest when GitLab answered with a status the
+// helper does not treat as success. Callers use errors.As to give the statuses
+// that mean something specific to their endpoint a message of their own; the
+// rest fall through to Error(), which is the wording every API function used to
+// build by hand.
+type apiError struct {
+	StatusCode int
+	Body       string
+}
 
-	req, err := http.NewRequest("GET", apiURL, http.NoBody)
+func (e *apiError) Error() string {
+	if e.Body == "" {
+		return fmt.Sprintf("HTTP %d", e.StatusCode)
+	}
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+// errUnauthorized is returned for every 401. GitLab answers 401 for the same
+// reason on every endpoint, so the advice lives in one place rather than being
+// re-worded per function.
+var errUnauthorized = errors.New("unauthorized access, check your access token is valid and has the api scope")
+
+// doRequest performs one GitLab API call and returns the raw response body.
+//
+// path is relative to /api/v4 and must already be escaped. body, when non-nil,
+// is sent as JSON. Any 2xx is success; 401 yields errUnauthorized and every
+// other status yields *apiError carrying the code and body.
+//
+// Decoding is left to the caller: the bodies are single objects, small enough
+// to hold in memory, and each caller has its own wording for a malformed one.
+func doRequest(
+	ctx context.Context, client *http.Client, config *Config,
+	method, path string, body any,
+) ([]byte, error) {
+	apiURL := fmt.Sprintf("%s/api/v4/%s", config.GitLabURL, path)
+
+	var reader io.Reader = http.NoBody
+	if body != nil {
+		jsonData, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		reader = bytes.NewBuffer(jsonData)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, apiURL, reader)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("PRIVATE-TOKEN", config.PrivateToken)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -528,16 +569,31 @@ func getProject(client *http.Client, config *Config) (*Project, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == 401 {
-		return nil, fmt.Errorf("unauthorized access, check your access token is valid")
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
 	}
 
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, errUnauthorized
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, &apiError{StatusCode: resp.StatusCode, Body: string(respBody)}
+	}
+
+	return respBody, nil
+}
+
+func getProject(ctx context.Context, client *http.Client, config *Config) (*Project, error) {
+	body, err := doRequest(ctx, client, config, http.MethodGet,
+		fmt.Sprintf("projects/%d", config.ProjectID), nil)
+	if err != nil {
+		return nil, err
 	}
 
 	var project Project
-	if err := json.NewDecoder(resp.Body).Decode(&project); err != nil {
+	if err := json.Unmarshal(body, &project); err != nil {
 		return nil, err
 	}
 
@@ -552,34 +608,21 @@ func validateMR(sourceBranch, targetBranch string) error {
 	return nil
 }
 
-func getExistingMR(client *http.Client, config *Config) (*MergeRequest, error) {
+func getExistingMR(ctx context.Context, client *http.Client, config *Config) (*MergeRequest, error) {
 	params := url.Values{}
 	params.Set("state", "opened")
 	params.Set("source_branch", config.SourceBranch)
 	params.Set("target_branch", config.TargetBranch)
 	params.Set("per_page", "1")
-	apiURL := fmt.Sprintf("%s/api/v4/projects/%d/merge_requests?%s",
-		config.GitLabURL, config.ProjectID, params.Encode())
 
-	req, err := http.NewRequest("GET", apiURL, http.NoBody)
+	body, err := doRequest(ctx, client, config, http.MethodGet,
+		fmt.Sprintf("projects/%d/merge_requests?%s", config.ProjectID, params.Encode()), nil)
 	if err != nil {
 		return nil, err
-	}
-
-	req.Header.Set("PRIVATE-TOKEN", config.PrivateToken)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
 	}
 
 	var mrs []MergeRequest
-	if err := json.NewDecoder(resp.Body).Decode(&mrs); err != nil {
+	if err := json.Unmarshal(body, &mrs); err != nil {
 		return nil, err
 	}
 
@@ -619,7 +662,7 @@ func getDescriptionData(descriptionPath string) string {
 	return string(data)
 }
 
-func getIssueData(client *http.Client, config *Config) (*Issue, error) {
+func getIssueData(ctx context.Context, client *http.Client, config *Config) (*Issue, error) {
 	re := regexp.MustCompile(`#(\d+)`)
 	matches := re.FindStringSubmatch(config.SourceBranch)
 	if len(matches) < 2 {
@@ -631,148 +674,84 @@ func getIssueData(client *http.Client, config *Config) (*Issue, error) {
 		return nil, fmt.Errorf("invalid issue number: %s", matches[1])
 	}
 
-	apiURL := fmt.Sprintf("%s/api/v4/projects/%d/issues/%d", config.GitLabURL, config.ProjectID, issueID)
-
-	req, err := http.NewRequest("GET", apiURL, http.NoBody)
+	body, err := doRequest(ctx, client, config, http.MethodGet,
+		fmt.Sprintf("projects/%d/issues/%d", config.ProjectID, issueID), nil)
 	if err != nil {
+		// Any answer from GitLab other than success means the issue is not
+		// usable here, whatever the status; transport errors are passed through.
+		var apiErr *apiError
+		if errors.As(err, &apiErr) {
+			return nil, fmt.Errorf("issue #%d not found", issueID)
+		}
 		return nil, err
-	}
-
-	req.Header.Set("PRIVATE-TOKEN", config.PrivateToken)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("issue #%d not found", issueID)
 	}
 
 	var issue Issue
-	if err := json.NewDecoder(resp.Body).Decode(&issue); err != nil {
+	if err := json.Unmarshal(body, &issue); err != nil {
 		return nil, err
 	}
 
 	return &issue, nil
 }
 
-func createMR(client *http.Client, config *Config, mrRequest *MRCreateRequest) (*MergeRequest, error) {
-	apiURL := fmt.Sprintf("%s/api/v4/projects/%d/merge_requests", config.GitLabURL, config.ProjectID)
-
-	jsonData, err := json.Marshal(mrRequest)
+func createMR(
+	ctx context.Context, client *http.Client, config *Config, mrRequest *MRCreateRequest,
+) (*MergeRequest, error) {
+	body, err := doRequest(ctx, client, config, http.MethodPost,
+		fmt.Sprintf("projects/%d/merge_requests", config.ProjectID), mrRequest)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", apiURL, bytes.NewBuffer(jsonData))
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("PRIVATE-TOKEN", config.PrivateToken)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 201 {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
-	}
-
+	// GitLab always sends the created MR back, but an empty body is not a
+	// failure: the MR exists, only its IID is unknown.
 	var mr MergeRequest
-	if err := json.NewDecoder(resp.Body).Decode(&mr); err != nil {
-		if err == io.EOF {
-			return &mr, nil
-		}
+	if len(body) == 0 {
+		return &mr, nil
+	}
+
+	if err := json.Unmarshal(body, &mr); err != nil {
 		return nil, fmt.Errorf("MR created but response is invalid: %v", err)
 	}
 
 	return &mr, nil
 }
 
-func updateMR(client *http.Client, config *Config, mrIID int, updateRequest *MRUpdateRequest) error {
-	apiURL := fmt.Sprintf("%s/api/v4/projects/%d/merge_requests/%d", config.GitLabURL, config.ProjectID, mrIID)
-
-	jsonData, err := json.Marshal(updateRequest)
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest("PUT", apiURL, bytes.NewBuffer(jsonData))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("PRIVATE-TOKEN", config.PrivateToken)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
-	}
-
-	return nil
+func updateMR(
+	ctx context.Context, client *http.Client, config *Config, mrIID int, updateRequest *MRUpdateRequest,
+) error {
+	_, err := doRequest(ctx, client, config, http.MethodPut,
+		fmt.Sprintf("projects/%d/merge_requests/%d", config.ProjectID, mrIID), updateRequest)
+	return err
 }
 
-func acceptMR(client *http.Client, config *Config, mrIID int) error {
-	apiURL := fmt.Sprintf("%s/api/v4/projects/%d/merge_requests/%d/merge", config.GitLabURL, config.ProjectID, mrIID)
-
+func acceptMR(ctx context.Context, client *http.Client, config *Config, mrIID int) error {
 	acceptRequest := &MRAcceptRequest{
 		MergeWhenPipelineSucceeds: true,
 		ShouldRemoveSourceBranch:  config.RemoveBranch,
 		Squash:                    config.SquashCommits,
 	}
 
-	jsonData, err := json.Marshal(acceptRequest)
-	if err != nil {
-		return err
+	_, err := doRequest(ctx, client, config, http.MethodPut,
+		fmt.Sprintf("projects/%d/merge_requests/%d/merge", config.ProjectID, mrIID), acceptRequest)
+
+	var apiErr *apiError
+	if errors.As(err, &apiErr) {
+		switch apiErr.StatusCode {
+		case http.StatusMethodNotAllowed:
+			return fmt.Errorf(
+				"merge request cannot be merged, " +
+					"the pipeline may not have started yet or other merge conditions are not met",
+			)
+		case http.StatusNotAcceptable:
+			return fmt.Errorf(
+				"merge request cannot be merged, " +
+					"there may be unresolved discussions or other blocking conditions",
+			)
+		}
 	}
 
-	req, err := http.NewRequest("PUT", apiURL, bytes.NewBuffer(jsonData))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("PRIVATE-TOKEN", config.PrivateToken)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	switch resp.StatusCode {
-	case 200:
-		return nil
-	case 401:
-		return fmt.Errorf("unauthorized access, check your access token permissions")
-	case 405:
-		return fmt.Errorf(
-			"merge request cannot be merged, " +
-				"the pipeline may not have started yet or other merge conditions are not met",
-		)
-	case 406:
-		return fmt.Errorf(
-			"merge request cannot be merged, " +
-				"there may be unresolved discussions or other blocking conditions",
-		)
-	default:
-		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
-	}
+	return err
 }
 
 func versionInfo() string {

--- a/main_test.go
+++ b/main_test.go
@@ -1792,16 +1792,72 @@ func TestIsRetryable(t *testing.T) {
 		{"POST dial error", http.MethodPost, dialErr, true},
 		{"POST read error is not repeated", http.MethodPost, readErr, false},
 		{"unauthorized", http.MethodGet, errUnauthorized, false},
-		{"canceled", http.MethodGet, context.Canceled, false},
-		{"deadline exceeded", http.MethodGet, context.DeadlineExceeded, false},
+		// A --timeout that elapsed surfaces as DeadlineExceeded while the caller's
+		// context is still live: that is a transient failure, so GET repeats it.
+		{"GET request timeout", http.MethodGet, context.DeadlineExceeded, true},
+		{"POST request timeout is not repeated", http.MethodPost, context.DeadlineExceeded, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isRetryable(tt.method, tt.err); got != tt.want {
+			if got := isRetryable(context.Background(), tt.method, tt.err); got != tt.want {
 				t.Errorf("isRetryable(%s, %v) = %v, want %v", tt.method, tt.err, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestIsRetryableStopsOnCancellation checks that a caller who gave up ends the
+// retries, however transient the underlying failure looks.
+func TestIsRetryableStopsOnCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if isRetryable(ctx, http.MethodGet, &apiError{StatusCode: 503}) {
+		t.Error("expected no retry once the caller's context is done")
+	}
+}
+
+// TestDoRequestRetriesRequestTimeout is the end-to-end form of the same rule:
+// a request that outran --timeout is retried, and the retry succeeds.
+func TestDoRequestRetriesRequestTimeout(t *testing.T) {
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts == 1 {
+			// Outlast the client timeout without hanging the test if it is not hit.
+			select {
+			case <-r.Context().Done():
+			case <-time.After(2 * time.Second):
+			}
+			return
+		}
+		if _, err := w.Write([]byte(`{"ok":true}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	config := &Config{
+		PrivateToken: "test-token",
+		ProjectID:    123,
+		GitLabURL:    server.URL,
+		Timeout:      100 * time.Millisecond,
+		Retries:      1,
+		RetryDelay:   time.Millisecond,
+	}
+
+	client := createHTTPClient(config)
+
+	body, err := doRequest(context.Background(), client, config, http.MethodGet, "projects/123", nil)
+	if err != nil {
+		t.Fatalf("doRequest() error = %v", err)
+	}
+	if string(body) != `{"ok":true}` {
+		t.Errorf("body = %q, want %q", string(body), `{"ok":true}`)
+	}
+	if attempts != 2 {
+		t.Errorf("attempts = %d, want 2", attempts)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -378,7 +379,7 @@ func TestGetProject(t *testing.T) {
 	}
 
 	// Test successful request
-	project, err := getProject(client, config)
+	project, err := getProject(context.Background(), client, config)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -394,7 +395,7 @@ func TestGetProject(t *testing.T) {
 
 	// Test unauthorized request
 	config.PrivateToken = ""
-	_, err = getProject(client, config)
+	_, err = getProject(context.Background(), client, config)
 	if err == nil {
 		t.Error("Expected error for unauthorized request")
 	}
@@ -456,7 +457,7 @@ func TestGetExistingMR(t *testing.T) {
 	}
 
 	// Test finding existing MR
-	mr, err := getExistingMR(client, config)
+	mr, err := getExistingMR(context.Background(), client, config)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -469,7 +470,7 @@ func TestGetExistingMR(t *testing.T) {
 
 	// Test not finding MR
 	config.SourceBranch = "feature/nonexistent"
-	mr, err = getExistingMR(client, config)
+	mr, err = getExistingMR(context.Background(), client, config)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -518,7 +519,7 @@ func TestGetExistingMRServerSideFiltering(t *testing.T) {
 		TargetBranch: "main",
 	}
 
-	mr, err := getExistingMR(client, config)
+	mr, err := getExistingMR(context.Background(), client, config)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -584,7 +585,7 @@ func TestGetExistingMRSpecialChars(t *testing.T) {
 		TargetBranch: targetBranch,
 	}
 
-	mr, err := getExistingMR(client, config)
+	mr, err := getExistingMR(context.Background(), client, config)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -631,7 +632,7 @@ func TestGetIssueData(t *testing.T) {
 	}
 
 	// Test successful request
-	issue, err := getIssueData(client, config)
+	issue, err := getIssueData(context.Background(), client, config)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -650,14 +651,14 @@ func TestGetIssueData(t *testing.T) {
 
 	// Test invalid branch name
 	config.SourceBranch = "feature/no-issue"
-	_, err = getIssueData(client, config)
+	_, err = getIssueData(context.Background(), client, config)
 	if err == nil {
 		t.Error("Expected error for invalid branch name")
 	}
 
 	// Test invalid issue number
 	config.SourceBranch = "feature/fix-#invalid"
-	_, err = getIssueData(client, config)
+	_, err = getIssueData(context.Background(), client, config)
 	if err == nil {
 		t.Error("Expected error for invalid issue number")
 	}
@@ -712,7 +713,7 @@ func TestCreateMR(t *testing.T) {
 		Description:  "Test description",
 	}
 
-	mr, err := createMR(client, config, mrRequest)
+	mr, err := createMR(context.Background(), client, config, mrRequest)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -728,7 +729,7 @@ func TestCreateMR(t *testing.T) {
 
 	// Test failed creation
 	mrRequest.SourceBranch = ""
-	_, err = createMR(client, config, mrRequest)
+	_, err = createMR(context.Background(), client, config, mrRequest)
 	if err == nil {
 		t.Error("Expected error for invalid request")
 	}
@@ -775,7 +776,7 @@ func TestUpdateMR(t *testing.T) {
 		Description: "Updated description",
 	}
 
-	err := updateMR(client, config, 1, updateRequest)
+	err := updateMR(context.Background(), client, config, 1, updateRequest)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -818,7 +819,7 @@ func TestRunCreateOnly(t *testing.T) {
 		SquashCommits: false,
 	}
 
-	err := run(config)
+	err := run(context.Background(), config)
 	if err != nil {
 		t.Errorf("Expected no error for create-only with no existing MR, got %v", err)
 	}
@@ -867,7 +868,7 @@ func TestRunUpdateOnly(t *testing.T) {
 		SquashCommits: false,
 	}
 
-	err := run(config)
+	err := run(context.Background(), config)
 	if err != nil {
 		t.Errorf("Expected no error for update-only with existing MR, got %v", err)
 	}
@@ -911,7 +912,7 @@ func TestRunMRExists(t *testing.T) {
 		MRExists:     true,
 	}
 
-	err := run(config)
+	err := run(context.Background(), config)
 	if err != nil {
 		t.Errorf("Expected no error for MR exists check, got %v", err)
 	}
@@ -928,7 +929,7 @@ func TestRunErrorCases(t *testing.T) {
 		UserIDs:      []int{1},
 	}
 
-	err := run(config)
+	err := run(context.Background(), config)
 	if err == nil {
 		t.Error("Expected error for same source and target branches")
 	}
@@ -969,7 +970,7 @@ func TestRunErrorCases(t *testing.T) {
 		CreateOnly:   true,
 	}
 
-	err = run(config)
+	err = run(context.Background(), config)
 	if err == nil {
 		t.Error("Expected error for create-only with existing MR")
 	}
@@ -1000,7 +1001,7 @@ func TestRunErrorCases(t *testing.T) {
 		UpdateMR:     true,
 	}
 
-	err = run(config)
+	err = run(context.Background(), config)
 	if err == nil {
 		t.Error("Expected error for update-only with no existing MR")
 	}
@@ -1060,13 +1061,13 @@ func TestErrorHandling(t *testing.T) {
 	}
 
 	// Test getProject error handling
-	_, err := getProject(client, config)
+	_, err := getProject(context.Background(), client, config)
 	if err == nil {
 		t.Error("Expected error for HTTP 500 response")
 	}
 
 	// Test getExistingMR error handling
-	_, err = getExistingMR(client, config)
+	_, err = getExistingMR(context.Background(), client, config)
 	if err == nil {
 		t.Error("Expected error for HTTP 500 response")
 	}
@@ -1117,7 +1118,7 @@ func TestRunExistingMRWithoutUpdateFlag(t *testing.T) {
 		SquashCommits: false,
 	}
 
-	err := run(config)
+	err := run(context.Background(), config)
 	if err != nil {
 		t.Errorf("Expected no error when MR exists without --update-mr flag, got %v", err)
 	}
@@ -1159,7 +1160,7 @@ func TestAcceptMR(t *testing.T) {
 		SquashCommits: true,
 	}
 
-	err := acceptMR(client, config, 42)
+	err := acceptMR(context.Background(), client, config, 42)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -1178,7 +1179,7 @@ func TestAcceptMR405(t *testing.T) {
 		PrivateToken: "test-token",
 	}
 
-	err := acceptMR(client, config, 42)
+	err := acceptMR(context.Background(), client, config, 42)
 	if err == nil {
 		t.Error("Expected error for 405 response")
 	}
@@ -1200,7 +1201,7 @@ func TestAcceptMR401(t *testing.T) {
 		PrivateToken: "bad-token",
 	}
 
-	err := acceptMR(client, config, 42)
+	err := acceptMR(context.Background(), client, config, 42)
 	if err == nil {
 		t.Error("Expected error for 401 response")
 	}
@@ -1222,7 +1223,7 @@ func TestAcceptMR406(t *testing.T) {
 		PrivateToken: "test-token",
 	}
 
-	err := acceptMR(client, config, 42)
+	err := acceptMR(context.Background(), client, config, 42)
 	if err == nil {
 		t.Error("Expected error for 406 response")
 	}
@@ -1262,7 +1263,7 @@ func TestAutoMergeWithDraftPrefixConflict(t *testing.T) {
 		CommitPrefix: "Draft",
 	}
 
-	err := run(config)
+	err := run(context.Background(), config)
 	if err == nil {
 		t.Error("Expected error for --auto-merge with draft prefix")
 	}
@@ -1272,7 +1273,7 @@ func TestAutoMergeWithDraftPrefixConflict(t *testing.T) {
 
 	// Also test with WIP prefix
 	config.CommitPrefix = "WIP"
-	err = run(config)
+	err = run(context.Background(), config)
 	if err == nil {
 		t.Error("Expected error for --auto-merge with WIP prefix")
 	}
@@ -1284,7 +1285,7 @@ func TestAutoMergeWithMRExistsConflict(t *testing.T) {
 		MRExists:  true,
 	}
 
-	err := run(config)
+	err := run(context.Background(), config)
 	if err == nil {
 		t.Error("Expected error for --auto-merge with --mr-exists")
 	}
@@ -1328,7 +1329,7 @@ func TestRunWithAutoMerge(t *testing.T) {
 		SquashCommits: false,
 	}
 
-	err := run(config)
+	err := run(context.Background(), config)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -1371,7 +1372,7 @@ func TestRunWithAutoMergeUpdate(t *testing.T) {
 		CommitPrefix: "",
 	}
 
-	err := run(config)
+	err := run(context.Background(), config)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -1394,7 +1395,7 @@ func TestCreateMREmptyResponseBody(t *testing.T) {
 		PrivateToken: "test-token",
 	}
 
-	mr, err := createMR(client, config, &MRCreateRequest{
+	mr, err := createMR(context.Background(), client, config, &MRCreateRequest{
 		SourceBranch: "feature/test",
 		TargetBranch: "main",
 		Title:        "Test MR",
@@ -1424,7 +1425,7 @@ func TestCreateMRInvalidResponseBody(t *testing.T) {
 		PrivateToken: "test-token",
 	}
 
-	_, err := createMR(client, config, &MRCreateRequest{
+	_, err := createMR(context.Background(), client, config, &MRCreateRequest{
 		SourceBranch: "feature/test",
 		TargetBranch: "main",
 		Title:        "Test MR",
@@ -1468,7 +1469,7 @@ func TestRunWithAutoMergeExistingMRNoUpdate(t *testing.T) {
 		CommitPrefix: "",
 	}
 
-	err := run(config)
+	err := run(context.Background(), config)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -1521,7 +1522,7 @@ func TestRunWithIssueData(t *testing.T) {
 		SquashCommits: false,
 	}
 
-	err := run(config)
+	err := run(context.Background(), config)
 	if err != nil {
 		t.Errorf("Expected no error for run with issue data, got %v", err)
 	}
@@ -1577,7 +1578,7 @@ func TestRunWithIssueDataError(t *testing.T) {
 		os.Stderr = origStderr
 	})
 
-	runErr := run(config)
+	runErr := run(context.Background(), config)
 
 	if cerr := wPipe.Close(); cerr != nil {
 		t.Fatalf("Failed to close stderr pipe: %v", cerr)
@@ -1600,6 +1601,162 @@ func TestRunWithIssueDataError(t *testing.T) {
 	}
 	if !strings.Contains(stderrOutput, "issue #789 not found") {
 		t.Errorf("Expected underlying error 'issue #789 not found' in warning, got: %q", stderrOutput)
+	}
+}
+
+// TestAPIErrorMessage pins the wording apiError produces, since it is what
+// every API function reports for an unexpected status.
+func TestAPIErrorMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *apiError
+		want string
+	}{
+		{"with body", &apiError{StatusCode: 400, Body: "bad request"}, "HTTP 400: bad request"},
+		{"empty body", &apiError{StatusCode: 500}, "HTTP 500"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.want {
+				t.Errorf("Error() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDoRequestUnauthorized checks that a 401 from any endpoint produces the
+// single shared errUnauthorized, so callers can match it with errors.Is.
+func TestDoRequestUnauthorized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	config := &Config{PrivateToken: "bad", ProjectID: 123, GitLabURL: server.URL}
+
+	_, err := doRequest(context.Background(), server.Client(), config, http.MethodGet, "projects/123", nil)
+	if !errors.Is(err, errUnauthorized) {
+		t.Errorf("expected errUnauthorized, got %v", err)
+	}
+}
+
+// TestDoRequestSendsTokenAndBody checks the three things the helper is
+// responsible for on the way out: the URL, the token header, and the JSON body
+// with its Content-Type. A GET must send neither body nor Content-Type.
+func TestDoRequestSendsTokenAndBody(t *testing.T) {
+	var (
+		gotPath        string
+		gotToken       string
+		gotContentType string
+		gotBody        string
+		gotMethod      string
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotToken = r.Header.Get("PRIVATE-TOKEN")
+		gotContentType = r.Header.Get("Content-Type")
+		gotMethod = r.Method
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		gotBody = string(body)
+		if _, err := w.Write([]byte(`{"ok":true}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	config := &Config{PrivateToken: "test-token", ProjectID: 123, GitLabURL: server.URL}
+
+	t.Run("post with body", func(t *testing.T) {
+		resp, err := doRequest(context.Background(), server.Client(), config,
+			http.MethodPost, "projects/123/merge_requests", map[string]string{"title": "x"})
+		if err != nil {
+			t.Fatalf("doRequest() error = %v", err)
+		}
+		if string(resp) != `{"ok":true}` {
+			t.Errorf("body = %q, want %q", string(resp), `{"ok":true}`)
+		}
+		if gotMethod != http.MethodPost {
+			t.Errorf("method = %q, want POST", gotMethod)
+		}
+		if gotPath != "/api/v4/projects/123/merge_requests" {
+			t.Errorf("path = %q", gotPath)
+		}
+		if gotToken != "test-token" {
+			t.Errorf("PRIVATE-TOKEN = %q, want %q", gotToken, "test-token")
+		}
+		if gotContentType != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", gotContentType)
+		}
+		if gotBody != `{"title":"x"}` {
+			t.Errorf("request body = %q, want %q", gotBody, `{"title":"x"}`)
+		}
+	})
+
+	t.Run("get without body", func(t *testing.T) {
+		if _, err := doRequest(context.Background(), server.Client(), config,
+			http.MethodGet, "projects/123", nil); err != nil {
+			t.Fatalf("doRequest() error = %v", err)
+		}
+		if gotBody != "" {
+			t.Errorf("GET sent a body: %q", gotBody)
+		}
+		if gotContentType != "" {
+			t.Errorf("GET sent Content-Type: %q", gotContentType)
+		}
+	})
+}
+
+// TestRunContextCancellation covers issue #69: a canceled context aborts the
+// request in flight rather than waiting out the client timeout.
+func TestRunContextCancellation(t *testing.T) {
+	released := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Hold the response until the client gives up on it.
+		select {
+		case <-released:
+		case <-r.Context().Done():
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer func() {
+		close(released)
+		server.Close()
+	}()
+
+	config := &Config{
+		PrivateToken: "test-token",
+		SourceBranch: "feature/test",
+		ProjectID:    123,
+		GitLabURL:    server.URL,
+		UserIDs:      []int{1},
+		TargetBranch: "main",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := run(ctx, config)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from the canceled request, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	// The client timeout is 30s; returning anywhere near it means cancellation
+	// was ignored.
+	if elapsed > 5*time.Second {
+		t.Errorf("run() took %v, expected it to abort as soon as the context was canceled", elapsed)
 	}
 }
 
@@ -1834,7 +1991,7 @@ func TestTriggerMRPipeline(t *testing.T) {
 		PrivateToken: "test-token",
 	}
 
-	if err := triggerMRPipeline(client, config, 42); err != nil {
+	if err := triggerMRPipeline(context.Background(), client, config, 42); err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
 }
@@ -1853,7 +2010,7 @@ func TestTriggerMRPipelineZeroIID(t *testing.T) {
 		PrivateToken: "test-token",
 	}
 
-	if err := triggerMRPipeline(client, config, 0); err != nil {
+	if err := triggerMRPipeline(context.Background(), client, config, 0); err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
 }
@@ -1886,7 +2043,7 @@ func TestTriggerMRPipelineErrors(t *testing.T) {
 				PrivateToken: "test-token",
 			}
 
-			err := triggerMRPipeline(client, config, 42)
+			err := triggerMRPipeline(context.Background(), client, config, 42)
 			if err == nil {
 				t.Fatal("Expected an error, got nil")
 			}
@@ -1913,7 +2070,7 @@ func TestTriggerMRPipelineUnreadableBody(t *testing.T) {
 		PrivateToken: "test-token",
 	}
 
-	if err := triggerMRPipeline(client, config, 42); err != nil {
+	if err := triggerMRPipeline(context.Background(), client, config, 42); err != nil {
 		t.Errorf("Expected no error for an unreadable body, got %v", err)
 	}
 }
@@ -1959,7 +2116,7 @@ func TestRunWithTriggerPipeline(t *testing.T) {
 		AutoMerge:       true,
 	}
 
-	if err := run(config); err != nil {
+	if err := run(context.Background(), config); err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
@@ -2003,7 +2160,7 @@ func TestRunWithoutTriggerPipeline(t *testing.T) {
 		UserIDs:      []int{1},
 	}
 
-	if err := run(config); err != nil {
+	if err := run(context.Background(), config); err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -332,7 +333,7 @@ func TestSmartMRManagement(t *testing.T) {
 
 func TestCreateHTTPClient(t *testing.T) {
 	// Test secure client
-	client := createHTTPClient(false)
+	client := createHTTPClient(&Config{})
 	if client == nil {
 		t.Fatal("Expected non-nil client")
 	}
@@ -341,12 +342,19 @@ func TestCreateHTTPClient(t *testing.T) {
 	}
 
 	// Test insecure client
-	insecureClient := createHTTPClient(true)
+	insecureClient := createHTTPClient(&Config{Insecure: true})
 	if insecureClient == nil {
 		t.Fatal("Expected non-nil insecure client")
 	}
 	if insecureClient.Timeout != 30*time.Second {
 		t.Errorf("Expected timeout 30s, got %v", insecureClient.Timeout)
+	}
+
+	// An explicit --timeout wins; a zero value keeps the 30s default, so a
+	// Config built without one behaves as it always did.
+	custom := createHTTPClient(&Config{Timeout: 5 * time.Second})
+	if custom.Timeout != 5*time.Second {
+		t.Errorf("Expected timeout 5s, got %v", custom.Timeout)
 	}
 }
 
@@ -1757,6 +1765,255 @@ func TestRunContextCancellation(t *testing.T) {
 	// was ignored.
 	if elapsed > 5*time.Second {
 		t.Errorf("run() took %v, expected it to abort as soon as the context was canceled", elapsed)
+	}
+}
+
+// TestIsRetryable pins the retry policy: idempotent verbs may repeat on
+// transient answers, POST may repeat only when the request never left.
+func TestIsRetryable(t *testing.T) {
+	dialErr := &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+	readErr := &net.OpError{Op: "read", Err: errors.New("connection reset by peer")}
+
+	tests := []struct {
+		name   string
+		method string
+		err    error
+		want   bool
+	}{
+		{"GET 500", http.MethodGet, &apiError{StatusCode: 500}, true},
+		{"GET 503", http.MethodGet, &apiError{StatusCode: 503}, true},
+		{"GET 429", http.MethodGet, &apiError{StatusCode: 429}, true},
+		{"GET 404", http.MethodGet, &apiError{StatusCode: 404}, false},
+		{"GET 400", http.MethodGet, &apiError{StatusCode: 400}, false},
+		{"PUT 502", http.MethodPut, &apiError{StatusCode: 502}, true},
+		{"POST 500 is not repeated", http.MethodPost, &apiError{StatusCode: 500}, false},
+		{"GET dial error", http.MethodGet, dialErr, true},
+		{"GET read error", http.MethodGet, readErr, true},
+		{"POST dial error", http.MethodPost, dialErr, true},
+		{"POST read error is not repeated", http.MethodPost, readErr, false},
+		{"unauthorized", http.MethodGet, errUnauthorized, false},
+		{"canceled", http.MethodGet, context.Canceled, false},
+		{"deadline exceeded", http.MethodGet, context.DeadlineExceeded, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRetryable(tt.method, tt.err); got != tt.want {
+				t.Errorf("isRetryable(%s, %v) = %v, want %v", tt.method, tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRetryDelay(t *testing.T) {
+	config := &Config{RetryDelay: time.Second}
+
+	tests := []struct {
+		name       string
+		config     *Config
+		attempt    int
+		retryAfter time.Duration
+		want       time.Duration
+	}{
+		{"first attempt", config, 0, 0, time.Second},
+		{"doubles", config, 1, 0, 2 * time.Second},
+		{"doubles again", config, 2, 0, 4 * time.Second},
+		{"capped", config, 20, 0, maxRetryDelay},
+		{"no overflow", config, 64, 0, maxRetryDelay},
+		{"zero delay falls back to the default", &Config{}, 0, 0, defaultRetryDelay},
+		{"Retry-After wins", config, 3, 7 * time.Second, 7 * time.Second},
+		{"Retry-After is capped too", config, 0, time.Hour, maxRetryDelay},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := retryDelay(tt.config, tt.attempt, tt.retryAfter); got != tt.want {
+				t.Errorf("retryDelay(attempt=%d, retryAfter=%s) = %s, want %s",
+					tt.attempt, tt.retryAfter, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	tests := []struct {
+		value string
+		want  time.Duration
+	}{
+		{"", 0},
+		{"5", 5 * time.Second},
+		{" 12 ", 12 * time.Second},
+		{"0", 0},
+		{"-1", 0},
+		{"Wed, 21 Oct 2015 07:28:00 GMT", 0},
+		{"nonsense", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			if got := parseRetryAfter(tt.value); got != tt.want {
+				t.Errorf("parseRetryAfter(%q) = %s, want %s", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDoRequestRetries covers issue #145 end-to-end against a server that fails
+// a fixed number of times before succeeding.
+func TestDoRequestRetries(t *testing.T) {
+	tests := []struct {
+		name         string
+		method       string
+		failures     int
+		failStatus   int
+		retries      int
+		wantAttempts int
+		wantErr      bool
+	}{
+		{"GET recovers from 503", http.MethodGet, 2, 503, 2, 3, false},
+		{"GET gives up after the last retry", http.MethodGet, 5, 503, 2, 3, true},
+		{"GET does not retry 404", http.MethodGet, 5, 404, 2, 1, true},
+		{"POST does not retry 503", http.MethodPost, 5, 503, 2, 1, true},
+		{"no retries configured", http.MethodGet, 1, 500, 0, 1, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var attempts int
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				attempts++
+				if attempts <= tt.failures {
+					w.WriteHeader(tt.failStatus)
+					return
+				}
+				if _, err := w.Write([]byte(`{"ok":true}`)); err != nil {
+					t.Errorf("write response: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			config := &Config{
+				PrivateToken: "test-token",
+				ProjectID:    123,
+				GitLabURL:    server.URL,
+				Retries:      tt.retries,
+				RetryDelay:   time.Millisecond,
+			}
+
+			var reqBody any
+			if tt.method == http.MethodPost {
+				reqBody = map[string]string{"title": "x"}
+			}
+
+			_, err := doRequest(context.Background(), server.Client(), config, tt.method, "projects/123", reqBody)
+
+			if tt.wantErr && err == nil {
+				t.Error("expected an error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if attempts != tt.wantAttempts {
+				t.Errorf("attempts = %d, want %d", attempts, tt.wantAttempts)
+			}
+		})
+	}
+}
+
+// TestDoRequestRespectsRetryAfter checks that a 429 carrying Retry-After waits
+// for the interval GitLab asked for rather than the configured backoff.
+func TestDoRequestRespectsRetryAfter(t *testing.T) {
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts++
+		if attempts == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		if _, err := w.Write([]byte(`{}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	config := &Config{
+		PrivateToken: "test-token",
+		ProjectID:    123,
+		GitLabURL:    server.URL,
+		Retries:      1,
+		RetryDelay:   time.Millisecond, // far shorter than the Retry-After
+	}
+
+	start := time.Now()
+	if _, err := doRequest(context.Background(), server.Client(), config,
+		http.MethodGet, "projects/123", nil); err != nil {
+		t.Fatalf("doRequest() error = %v", err)
+	}
+	elapsed := time.Since(start)
+
+	if attempts != 2 {
+		t.Errorf("attempts = %d, want 2", attempts)
+	}
+	if elapsed < time.Second {
+		t.Errorf("waited %s, expected at least the 1s from Retry-After", elapsed)
+	}
+}
+
+// TestDoRequestRetrySendsBodyAgain guards against the reader being consumed by
+// the first attempt: a retried PUT must send the same payload.
+func TestDoRequestRetrySendsBodyAgain(t *testing.T) {
+	var bodies []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		bodies = append(bodies, string(body))
+		if len(bodies) == 1 {
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		if _, werr := w.Write([]byte(`{}`)); werr != nil {
+			t.Errorf("write response: %v", werr)
+		}
+	}))
+	defer server.Close()
+
+	config := &Config{
+		PrivateToken: "test-token",
+		ProjectID:    123,
+		GitLabURL:    server.URL,
+		Retries:      1,
+		RetryDelay:   time.Millisecond,
+	}
+
+	if _, err := doRequest(context.Background(), server.Client(), config,
+		http.MethodPut, "projects/123/merge_requests/1", map[string]string{"title": "x"}); err != nil {
+		t.Fatalf("doRequest() error = %v", err)
+	}
+
+	if len(bodies) != 2 {
+		t.Fatalf("got %d attempts, want 2", len(bodies))
+	}
+	if bodies[0] != bodies[1] {
+		t.Errorf("retry sent %q, first attempt sent %q", bodies[1], bodies[0])
+	}
+}
+
+// TestSleepRespectsContext checks that a canceled context ends the backoff wait
+// immediately instead of blocking for the full delay.
+func TestSleepRespectsContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	err := sleep(ctx, time.Hour)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("sleep returned after %s, expected it to be immediate", elapsed)
 	}
 }
 


### PR DESCRIPTION
Closes #145, closes #77 (the two describe the same feature).

> **Stacked on #161.** Base is `refactor/http-helper`, because the retry loop belongs in the `doRequest` helper that PR introduces. Review #161 first; this diff shows only the retry work.

## Behaviour

Two retries by default, waiting 1s then 2s, capped at 30s. `--retries 0` turns it off. `--timeout` (default 30s) replaces the hardcoded client timeout, since with retries the total time budget becomes something worth controlling. All three read env vars too: `GITLAB_AUTO_MR_RETRIES`, `GITLAB_AUTO_MR_RETRY_DELAY`, `GITLAB_AUTO_MR_TIMEOUT`.

Default is 2 rather than #77's suggested 0: the motivation in #145 is that the tool *reads as flaky* when a restarting GitLab fails a job that a re-run would have fixed. Opt-in retries do not fix that for anyone who never reads the flag list.

## What may be retried

The issue's central warning — "retrying `POST /merge_requests` after a timeout could create a second MR" — is what the policy is built around. The question is not only *what failed* but *what a repeat could do*:

| Request | 5xx / 429 | network error |
| --- | --- | --- |
| `GET`, `PUT` | retried | retried |
| `POST` | not retried | only on a dial failure |

`GET` and `PUT` are idempotent, so at worst GitLab applies the same change twice. For `POST`, a dial failure is the one case where the request demonstrably never reached the server, so it is the one case that is safe to repeat.

4xx answers other than 429 are never retried — they are real answers, and repeating them only delays the error. Neither is a 401 (it will not become valid) or a cancelled context.

`Retry-After` wins over the computed backoff when GitLab sends it, capped at 30s. Only the delay-seconds form is parsed; the HTTP-date form is ignored rather than guessed at.

Backoff waiting goes through a `sleep` that selects on `ctx.Done()`, so Ctrl-C during a retry wait exits immediately rather than after the delay.

## Zero values still behave

Defaults are applied where they are used, not only in `parseFlags`, so a `Config` built directly — as every test does — keeps the old behaviour: no retries and a 30s timeout.

## Tests

- `TestIsRetryable` — 14 cases pinning the table above, including that a `read` error on POST is *not* retried while a `dial` error is.
- `TestRetryDelay` — doubling, the cap, shift overflow at attempt 64, zero-value fallback, `Retry-After` precedence.
- `TestParseRetryAfter` — seconds, whitespace, negative, HTTP-date, garbage.
- `TestDoRequestRetries` — five end-to-end cases counting actual server hits: recovery after two 503s, giving up after the last retry, no retry on 404, no retry on POST 503, and `--retries 0`.
- `TestDoRequestRespectsRetryAfter` — a 429 with `Retry-After: 1` waits ≥1s despite a 1ms configured delay.
- `TestDoRequestRetrySendsBodyAgain` — the retried PUT sends the same body, guarding against a consumed reader.
- `TestSleepRespectsContext` — a cancelled context ends the wait immediately.

```
$ go test -race ./...
ok  	gitlab-auto-mr	3.008s
$ golangci-lint run
0 issues.
```