### PR TITLE
feat: add --ca-cert for a self-hosted GitLab behind a private CA

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ create_only:
   `--target-branch`/`-t`; when neither is set, the project's default branch is used.
 - `GITLAB_AUTO_MR_LABELS` - Labels for the MR (comma-separated). Overridden by `--label`.
 - `GITLAB_AUTO_MR_MILESTONE` - Milestone ID for the MR. Overridden by `--milestone`.
+- `GITLAB_AUTO_MR_TIMEOUT` - Timeout for a single API request (default `30s`)
+- `GITLAB_AUTO_MR_RETRIES` - Retries for transient failures (default `2`)
+- `GITLAB_AUTO_MR_RETRY_DELAY` - Delay before the first retry (default `1s`)
 
 ### CLI Options
 
@@ -174,6 +177,10 @@ create_only:
 | `--auto-merge`          |       | Enable merge when pipeline succeeds (auto-merge) | `false`              |
 | `--trigger-pipeline`    |       | Create a merge request pipeline for the created or updated MR | `false`   |
 | `--force-pipeline`      |       | With `--trigger-pipeline`, create one even if the commit has one | `false` |
+| `--trigger-pipeline`    |       | Create a merge request pipeline after the MR is created | `false`         |
+| `--timeout`             |       | Timeout for a single API request               | `30s`                  |
+| `--retries`             |       | Retries for transient failures (5xx, 429, network) | `2`                |
+| `--retry-delay`         |       | Delay before the first retry, doubled each time | `1s`                  |
 | `--insecure`            | `-k`  | Skip SSL certificate verification              | `false`                |
 
 ### Merge Request Pipelines
@@ -221,6 +228,28 @@ Two things to expect:
   role on the project. A `CI_JOB_TOKEN` cannot be used: the Merge Requests API
   is read-only for job tokens, so it can neither create the MR nor request a
   pipeline for it.
+
+## Retries
+
+Self-hosted GitLab returns 502/503 during restarts and upgrades, and CI runners
+hit transient network errors. By default the tool retries such a failure twice,
+waiting 1s and then 2s, so a job does not fail for a reason that a re-run would
+have fixed anyway. `--retries 0` turns it off.
+
+What gets retried depends on what a repeat could do:
+
+| Request | Retried on 5xx / 429 | Retried on a network error |
+| --- | --- | --- |
+| `GET`, `PUT` | yes | yes |
+| `POST` | no | only if the connection was never established |
+
+`POST /merge_requests` is the reason for the asymmetry: retrying it after a
+timeout could open a second merge request. A failure to dial is safe to repeat,
+because the request demonstrably never reached GitLab.
+
+A `Retry-After` header — which GitLab sends when rate limiting — takes
+precedence over the backoff, capped at 30s. 4xx answers other than 429 are never
+retried: they are real answers, and repeating them only delays the error.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ create_only:
   `--target-branch`/`-t`; when neither is set, the project's default branch is used.
 - `GITLAB_AUTO_MR_LABELS` - Labels for the MR (comma-separated). Overridden by `--label`.
 - `GITLAB_AUTO_MR_MILESTONE` - Milestone ID for the MR. Overridden by `--milestone`.
+- `GITLAB_AUTO_MR_CA_CERT` - Path to a PEM CA certificate to trust in addition to the system pool
 - `GITLAB_AUTO_MR_TIMEOUT` - Timeout for a single API request (default `30s`)
 - `GITLAB_AUTO_MR_RETRIES` - Retries for transient failures (default `2`)
 - `GITLAB_AUTO_MR_RETRY_DELAY` - Delay before the first retry (default `1s`)
@@ -181,6 +182,7 @@ create_only:
 | `--timeout`             |       | Timeout for a single API request               | `30s`                  |
 | `--retries`             |       | Retries for transient failures (5xx, 429, network) | `2`                |
 | `--retry-delay`         |       | Delay before the first retry, doubled each time | `1s`                  |
+| `--ca-cert`             |       | PEM CA certificate to trust (`GITLAB_AUTO_MR_CA_CERT`) | -               |
 | `--insecure`            | `-k`  | Skip SSL certificate verification              | `false`                |
 
 ### Merge Request Pipelines
@@ -228,6 +230,20 @@ Two things to expect:
   role on the project. A `CI_JOB_TOKEN` cannot be used: the Merge Requests API
   is read-only for job tokens, so it can neither create the MR nor request a
   pipeline for it.
+
+## Self-hosted GitLab with a private CA
+
+If your instance presents a certificate from an internal CA, point the tool at
+that CA rather than turning verification off:
+
+```bash
+gitlab-auto-mr --ca-cert /etc/ssl/certs/internal-ca.pem
+```
+
+The certificate is added to the system trust store rather than replacing it, so
+other hosts keep working. `--insecure`/`-k` remains available for throwaway
+cases, but the two are mutually exclusive: disabling verification would make the
+CA pointless, and this tool carries an `api`-scoped token.
 
 ## Retries
 

--- a/README.md
+++ b/README.md
@@ -247,6 +247,9 @@ What gets retried depends on what a repeat could do:
 timeout could open a second merge request. A failure to dial is safe to repeat,
 because the request demonstrably never reached GitLab.
 
+A request that outran `--timeout` counts as a network error here, so a hung GET
+is retried. Ctrl-C is not: once the caller has given up, nothing is retried.
+
 A `Retry-After` header — which GitLab sends when rate limiting — takes
 precedence over the backoff, capped at 30s. 4xx answers other than 429 are never
 retried: they are real answers, and repeating them only delays the error.

--- a/main.go
+++ b/main.go
@@ -756,7 +756,7 @@ func doRequest(
 			return respBody, nil
 		}
 
-		if attempt >= config.Retries || !isRetryable(method, err) {
+		if attempt >= config.Retries || !isRetryable(ctx, method, err) {
 			return nil, err
 		}
 
@@ -821,9 +821,16 @@ func sendRequest(
 // same change twice. POST is not — retrying POST /merge_requests after a
 // timeout could open a second MR — so it is repeated only when the request
 // demonstrably never reached GitLab, which is what a dial failure means.
-func isRetryable(method string, err error) bool {
-	if errors.Is(err, errUnauthorized) || errors.Is(err, context.Canceled) ||
-		errors.Is(err, context.DeadlineExceeded) {
+//
+// Whether the caller gave up is read from ctx, not from err. A --timeout that
+// elapsed also surfaces as context.DeadlineExceeded, and that one is a
+// transient failure worth repeating — the very case retries exist for.
+func isRetryable(ctx context.Context, method string, err error) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+
+	if errors.Is(err, errUnauthorized) {
 		return false
 	}
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -76,6 +77,7 @@ type Config struct {
 	Timeout            time.Duration
 	Retries            int
 	RetryDelay         time.Duration
+	CACert             string
 }
 
 type Project struct {
@@ -181,6 +183,8 @@ func parseFlags() (*Config, error) {
 	flag.StringVar(&reviewerIDsStr, "reviewer-id", "", "Reviewer IDs (comma-separated)")
 	flag.BoolVar(&config.Insecure, "insecure", false, "Skip SSL verification")
 	flag.BoolVar(&config.Insecure, "k", false, "Skip SSL verification (short)")
+	flag.StringVar(&config.CACert, "ca-cert", getEnv("GITLAB_AUTO_MR_CA_CERT", ""),
+		"Path to a PEM CA certificate to trust in addition to the system pool")
 	// Both spellings share one variable, so they must share one default: whichever
 	// flag.StringVar runs last decides the initial value.
 	targetBranchDefault := getEnv("GITLAB_AUTO_MR_TARGET_BRANCH", "")
@@ -284,6 +288,13 @@ func isDraftPrefix(prefix string) bool {
 }
 
 func validateConfig(config *Config) error {
+	if config.CACert != "" && config.Insecure {
+		return fmt.Errorf(
+			"--ca-cert cannot be used with --insecure: " +
+				"--insecure disables verification entirely, which would make the CA pointless",
+		)
+	}
+
 	if config.ForcePipeline && !config.TriggerPipeline {
 		return fmt.Errorf("--force-pipeline has no effect without --trigger-pipeline")
 	}
@@ -321,7 +332,10 @@ func run(ctx context.Context, config *Config) error {
 		return err
 	}
 
-	client := createHTTPClient(config)
+	client, err := createHTTPClient(config)
+	if err != nil {
+		return err
+	}
 
 	project, err := getProject(ctx, client, config)
 	if err != nil {
@@ -683,7 +697,7 @@ func urlSuffix(webURL string) string {
 	return ": " + webURL
 }
 
-func createHTTPClient(config *Config) *http.Client {
+func createHTTPClient(config *Config) (*http.Client, error) {
 	timeout := config.Timeout
 	if timeout <= 0 {
 		timeout = defaultTimeout
@@ -693,16 +707,46 @@ func createHTTPClient(config *Config) *http.Client {
 		Timeout: timeout,
 	}
 
-	if config.Insecure {
-		// #nosec G402 -- certificate verification is disabled only at the user's
-		// explicit request, via --insecure/-k.
-		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	switch {
+	case config.Insecure:
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // user-requested via --insecure flag
 		}
-		client.Transport = tr
+
+	case config.CACert != "":
+		pool, err := caCertPool(config.CACert)
+		if err != nil {
+			return nil, err
+		}
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12},
+		}
 	}
 
-	return client
+	return client, nil
+}
+
+// caCertPool returns the system trust store with the given PEM certificate
+// added. It is additive on purpose: a self-hosted GitLab behind an internal CA
+// is usually reached alongside other hosts with public certificates.
+func caCertPool(path string) (*x509.CertPool, error) {
+	pem, err := os.ReadFile(path) //nolint:gosec // path is the caller's own --ca-cert value
+	if err != nil {
+		return nil, fmt.Errorf("unable to read CA certificate %s: %w", path, err)
+	}
+
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		// Windows returns an error here rather than a pool; starting from an
+		// empty one still lets the given CA work.
+		pool = x509.NewCertPool()
+	}
+
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, fmt.Errorf("no PEM certificate found in %s", path)
+	}
+
+	return pool, nil
 }
 
 // apiError is returned by doRequest when GitLab answered with a status the

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -32,6 +33,15 @@ var (
 const (
 	draftPrefix = "draft"
 	wipPrefix   = "wip"
+)
+
+// Defaults for the HTTP behavior. They are applied where they are used, not
+// only in parseFlags, so a zero-valued Config still behaves like the tool did
+// before these flags existed.
+const (
+	defaultTimeout    = 30 * time.Second
+	defaultRetryDelay = time.Second
+	maxRetryDelay     = 30 * time.Second
 )
 
 // errShowVersion is a sentinel error returned by parseFlags when --version has
@@ -63,6 +73,9 @@ type Config struct {
 	Labels             []string
 	MilestoneID        int
 	ForcePipeline      bool
+	Timeout            time.Duration
+	Retries            int
+	RetryDelay         time.Duration
 }
 
 type Project struct {
@@ -198,6 +211,13 @@ func parseFlags() (*Config, error) {
 		"With --trigger-pipeline, create a pipeline even if one exists for the same commit")
 	flag.BoolVar(&config.TriggerPipeline, "trigger-pipeline", false,
 		"Create a merge request pipeline for the MR, whether it was created or updated")
+	flag.DurationVar(&config.Timeout, "timeout", getEnvDuration("GITLAB_AUTO_MR_TIMEOUT", defaultTimeout),
+		"Timeout for a single GitLab API request")
+	flag.IntVar(&config.Retries, "retries", getEnvInt("GITLAB_AUTO_MR_RETRIES", 2),
+		"Retries for transient GitLab failures (network errors, 5xx, 429)")
+	flag.DurationVar(&config.RetryDelay, "retry-delay",
+		getEnvDuration("GITLAB_AUTO_MR_RETRY_DELAY", defaultRetryDelay),
+		"Delay before the first retry, doubled on each further attempt")
 	flag.BoolVar(&showVersion, "version", false, "Show version information and exit")
 	flag.BoolVar(&showVersion, "v", false, "Show version information and exit (short)")
 
@@ -223,6 +243,16 @@ func parseFlags() (*Config, error) {
 	}
 	if userIDsStr == "" {
 		return nil, fmt.Errorf("--user-id is required")
+	}
+
+	if config.Timeout <= 0 {
+		return nil, fmt.Errorf("--timeout must be positive, got %s", config.Timeout)
+	}
+	if config.Retries < 0 {
+		return nil, fmt.Errorf("--retries must not be negative, got %d", config.Retries)
+	}
+	if config.RetryDelay < 0 {
+		return nil, fmt.Errorf("--retry-delay must not be negative, got %s", config.RetryDelay)
 	}
 
 	// Parse user IDs
@@ -291,7 +321,7 @@ func run(ctx context.Context, config *Config) error {
 		return err
 	}
 
-	client := createHTTPClient(config.Insecure)
+	client := createHTTPClient(config)
 
 	project, err := getProject(ctx, client, config)
 	if err != nil {
@@ -653,12 +683,17 @@ func urlSuffix(webURL string) string {
 	return ": " + webURL
 }
 
-func createHTTPClient(insecure bool) *http.Client {
-	client := &http.Client{
-		Timeout: 30 * time.Second,
+func createHTTPClient(config *Config) *http.Client {
+	timeout := config.Timeout
+	if timeout <= 0 {
+		timeout = defaultTimeout
 	}
 
-	if insecure {
+	client := &http.Client{
+		Timeout: timeout,
+	}
+
+	if config.Insecure {
 		// #nosec G402 -- certificate verification is disabled only at the user's
 		// explicit request, via --insecure/-k.
 		tr := &http.Transport{
@@ -692,7 +727,8 @@ func (e *apiError) Error() string {
 // re-worded per function.
 var errUnauthorized = errors.New("unauthorized access, check your access token is valid and has the api scope")
 
-// doRequest performs one GitLab API call and returns the raw response body.
+// doRequest performs one GitLab API call and returns the raw response body,
+// retrying the attempt when the failure looks transient.
 //
 // path is relative to /api/v4 and must already be escaped. body, when non-nil,
 // is sent as JSON. Any 2xx is success; 401 yields errUnauthorized and every
@@ -706,45 +742,172 @@ func doRequest(
 ) ([]byte, error) {
 	apiURL := fmt.Sprintf("%s/api/v4/%s", config.GitLabURL, path)
 
-	var reader io.Reader = http.NoBody
+	var jsonData []byte
 	if body != nil {
-		jsonData, err := json.Marshal(body)
-		if err != nil {
+		var err error
+		if jsonData, err = json.Marshal(body); err != nil {
 			return nil, err
 		}
-		reader = bytes.NewBuffer(jsonData)
+	}
+
+	for attempt := 0; ; attempt++ {
+		respBody, retryAfter, err := sendRequest(ctx, client, config, method, apiURL, jsonData, body != nil)
+		if err == nil {
+			return respBody, nil
+		}
+
+		if attempt >= config.Retries || !isRetryable(method, err) {
+			return nil, err
+		}
+
+		delay := retryDelay(config, attempt, retryAfter)
+		fmt.Fprintf(os.Stderr, "Warning: %s %s failed (%v), retrying in %s (%d/%d)\n",
+			method, path, err, delay, attempt+1, config.Retries)
+
+		if err := sleep(ctx, delay); err != nil {
+			return nil, err
+		}
+	}
+}
+
+// sendRequest performs a single attempt. The returned duration is the value of
+// a Retry-After header, when GitLab sent one that could be parsed.
+func sendRequest(
+	ctx context.Context, client *http.Client, config *Config,
+	method, apiURL string, jsonData []byte, hasBody bool,
+) ([]byte, time.Duration, error) {
+	var reader io.Reader = http.NoBody
+	if hasBody {
+		reader = bytes.NewReader(jsonData)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, method, apiURL, reader)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	req.Header.Set("PRIVATE-TOKEN", config.PrivateToken)
-	if body != nil {
+	if hasBody {
 		req.Header.Set("Content-Type", "application/json")
 	}
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	defer resp.Body.Close()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, errUnauthorized
+		return nil, 0, errUnauthorized
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, &apiError{StatusCode: resp.StatusCode, Body: string(respBody)}
+		return nil, parseRetryAfter(resp.Header.Get("Retry-After")),
+			&apiError{StatusCode: resp.StatusCode, Body: string(respBody)}
 	}
 
-	return respBody, nil
+	return respBody, 0, nil
+}
+
+// isRetryable decides whether a failed attempt is worth repeating.
+//
+// The rule is about what a repeat could do, not only about what failed. GET and
+// PUT are idempotent, so repeating one is harmless: at worst GitLab applies the
+// same change twice. POST is not — retrying POST /merge_requests after a
+// timeout could open a second MR — so it is repeated only when the request
+// demonstrably never reached GitLab, which is what a dial failure means.
+func isRetryable(method string, err error) bool {
+	if errors.Is(err, errUnauthorized) || errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	var apiErr *apiError
+	if errors.As(err, &apiErr) {
+		// GitLab answered, so the request did reach it: repeating is only safe
+		// for the idempotent verbs.
+		if !isIdempotent(method) {
+			return false
+		}
+		return apiErr.StatusCode >= 500 || apiErr.StatusCode == http.StatusTooManyRequests
+	}
+
+	if isIdempotent(method) {
+		return true
+	}
+
+	return isDialError(err)
+}
+
+func isIdempotent(method string) bool {
+	return method == http.MethodGet || method == http.MethodPut || method == http.MethodHead
+}
+
+// isDialError reports whether the connection was never established, which means
+// the server cannot have seen the request.
+func isDialError(err error) bool {
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return opErr.Op == "dial"
+	}
+	return false
+}
+
+// retryDelay is the exponential backoff, unless GitLab asked for a specific
+// wait via Retry-After — it knows better, and ignoring it on a 429 only earns
+// another one.
+func retryDelay(config *Config, attempt int, retryAfter time.Duration) time.Duration {
+	if retryAfter > 0 {
+		if retryAfter > maxRetryDelay {
+			return maxRetryDelay
+		}
+		return retryAfter
+	}
+
+	base := config.RetryDelay
+	if base <= 0 {
+		base = defaultRetryDelay
+	}
+
+	delay := base << attempt
+	// Shifting past the width of the type wraps; both cases mean "too long".
+	if delay > maxRetryDelay || delay <= 0 {
+		return maxRetryDelay
+	}
+	return delay
+}
+
+// parseRetryAfter reads the delay-seconds form of Retry-After, which is what
+// GitLab sends. The HTTP-date form is ignored rather than guessed at.
+func parseRetryAfter(value string) time.Duration {
+	if value == "" {
+		return 0
+	}
+
+	seconds, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || seconds < 0 {
+		return 0
+	}
+
+	return time.Duration(seconds) * time.Second
+}
+
+// sleep waits for d, or returns early if the context is canceled first.
+func sleep(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func getProject(ctx context.Context, client *http.Client, config *Config) (*Project, error) {
@@ -923,6 +1086,15 @@ func versionInfo() string {
 func getEnv(key, defaultValue string) string {
 	if value := os.Getenv(key); value != "" {
 		return value
+	}
+	return defaultValue
+}
+
+func getEnvDuration(key string, defaultValue time.Duration) time.Duration {
+	if value := os.Getenv(key); value != "" {
+		if d, err := time.ParseDuration(value); err == nil {
+			return d
+		}
 	}
 	return defaultValue
 }

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"flag"
 	"io"
@@ -11,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -334,7 +336,10 @@ func TestSmartMRManagement(t *testing.T) {
 
 func TestCreateHTTPClient(t *testing.T) {
 	// Test secure client
-	client := createHTTPClient(&Config{})
+	client, err := createHTTPClient(&Config{})
+	if err != nil {
+		t.Fatalf("createHTTPClient() error = %v", err)
+	}
 	if client == nil {
 		t.Fatal("Expected non-nil client")
 	}
@@ -343,7 +348,10 @@ func TestCreateHTTPClient(t *testing.T) {
 	}
 
 	// Test insecure client
-	insecureClient := createHTTPClient(&Config{Insecure: true})
+	insecureClient, err := createHTTPClient(&Config{Insecure: true})
+	if err != nil {
+		t.Fatalf("createHTTPClient() error = %v", err)
+	}
 	if insecureClient == nil {
 		t.Fatal("Expected non-nil insecure client")
 	}
@@ -353,7 +361,10 @@ func TestCreateHTTPClient(t *testing.T) {
 
 	// An explicit --timeout wins; a zero value keeps the 30s default, so a
 	// Config built without one behaves as it always did.
-	custom := createHTTPClient(&Config{Timeout: 5 * time.Second})
+	custom, err := createHTTPClient(&Config{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("createHTTPClient() error = %v", err)
+	}
 	if custom.Timeout != 5*time.Second {
 		t.Errorf("Expected timeout 5s, got %v", custom.Timeout)
 	}
@@ -2369,7 +2380,10 @@ func TestDoRequestRetriesRequestTimeout(t *testing.T) {
 		RetryDelay:   time.Millisecond,
 	}
 
-	client := createHTTPClient(config)
+	client, err := createHTTPClient(config)
+	if err != nil {
+		t.Fatalf("createHTTPClient() error = %v", err)
+	}
 
 	body, err := doRequest(context.Background(), client, config, http.MethodGet, "projects/123", nil)
 	if err != nil {
@@ -2592,6 +2606,106 @@ func TestSleepRespectsContext(t *testing.T) {
 	}
 	if elapsed := time.Since(start); elapsed > time.Second {
 		t.Errorf("sleep returned after %s, expected it to be immediate", elapsed)
+	}
+}
+
+// writeServerCertPEM writes the certificate an httptest TLS server presents to
+// a temporary PEM file and returns its path.
+func writeServerCertPEM(t *testing.T, server *httptest.Server) string {
+	t.Helper()
+
+	cert := server.Certificate()
+	if cert == nil {
+		t.Fatal("server has no certificate")
+	}
+
+	path := filepath.Join(t.TempDir(), "ca.pem")
+	data := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+
+	return path
+}
+
+// TestCACert covers issue #146: a certificate given with --ca-cert is trusted
+// in addition to the system pool, so a self-hosted GitLab behind a private CA
+// can be reached without disabling verification.
+func TestCACert(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := w.Write([]byte(`{"id":123,"default_branch":"main"}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	certPath := writeServerCertPEM(t, server)
+
+	t.Run("trusted with --ca-cert", func(t *testing.T) {
+		config := &Config{PrivateToken: "tok", ProjectID: 123, GitLabURL: server.URL, CACert: certPath}
+
+		client, err := createHTTPClient(config)
+		if err != nil {
+			t.Fatalf("createHTTPClient() error = %v", err)
+		}
+
+		project, err := getProject(context.Background(), client, config)
+		if err != nil {
+			t.Fatalf("getProject() error = %v", err)
+		}
+		if project.ID != 123 {
+			t.Errorf("project.ID = %d, want 123", project.ID)
+		}
+	})
+
+	t.Run("rejected without it", func(t *testing.T) {
+		config := &Config{PrivateToken: "tok", ProjectID: 123, GitLabURL: server.URL}
+
+		client, err := createHTTPClient(config)
+		if err != nil {
+			t.Fatalf("createHTTPClient() error = %v", err)
+		}
+
+		if _, err := getProject(context.Background(), client, config); err == nil {
+			t.Error("expected a certificate verification error, got nil")
+		}
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		_, err := createHTTPClient(&Config{CACert: filepath.Join(t.TempDir(), "absent.pem")})
+		if err == nil {
+			t.Fatal("expected an error for a missing CA file")
+		}
+		if !strings.Contains(err.Error(), "unable to read CA certificate") {
+			t.Errorf("error = %v, want it to mention the unreadable file", err)
+		}
+	})
+
+	t.Run("file without a certificate", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "junk.pem")
+		if err := os.WriteFile(path, []byte("not a certificate"), 0o600); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+
+		_, err := createHTTPClient(&Config{CACert: path})
+		if err == nil {
+			t.Fatal("expected an error for a file with no PEM certificate")
+		}
+		if !strings.Contains(err.Error(), "no PEM certificate found") {
+			t.Errorf("error = %v, want it to mention the missing certificate", err)
+		}
+	})
+}
+
+// TestCACertWithInsecureRejected checks the two flags are refused together
+// rather than one silently winning.
+func TestCACertWithInsecureRejected(t *testing.T) {
+	err := validateConfig(&Config{CACert: "/tmp/ca.pem", Insecure: true})
+	if err == nil {
+		t.Fatal("expected an error for --ca-cert with --insecure")
+	}
+	if !strings.Contains(err.Error(), "--ca-cert cannot be used with --insecure") {
+		t.Errorf("error = %v", err)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"flag"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -333,7 +334,7 @@ func TestSmartMRManagement(t *testing.T) {
 
 func TestCreateHTTPClient(t *testing.T) {
 	// Test secure client
-	client := createHTTPClient(false)
+	client := createHTTPClient(&Config{})
 	if client == nil {
 		t.Fatal("Expected non-nil client")
 	}
@@ -342,12 +343,19 @@ func TestCreateHTTPClient(t *testing.T) {
 	}
 
 	// Test insecure client
-	insecureClient := createHTTPClient(true)
+	insecureClient := createHTTPClient(&Config{Insecure: true})
 	if insecureClient == nil {
 		t.Fatal("Expected non-nil insecure client")
 	}
 	if insecureClient.Timeout != 30*time.Second {
 		t.Errorf("Expected timeout 30s, got %v", insecureClient.Timeout)
+	}
+
+	// An explicit --timeout wins; a zero value keeps the 30s default, so a
+	// Config built without one behaves as it always did.
+	custom := createHTTPClient(&Config{Timeout: 5 * time.Second})
+	if custom.Timeout != 5*time.Second {
+		t.Errorf("Expected timeout 5s, got %v", custom.Timeout)
 	}
 }
 
@@ -2279,6 +2287,255 @@ func TestRunContextCancellation(t *testing.T) {
 	// was ignored.
 	if elapsed > 5*time.Second {
 		t.Errorf("run() took %v, expected it to abort as soon as the context was canceled", elapsed)
+	}
+}
+
+// TestIsRetryable pins the retry policy: idempotent verbs may repeat on
+// transient answers, POST may repeat only when the request never left.
+func TestIsRetryable(t *testing.T) {
+	dialErr := &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+	readErr := &net.OpError{Op: "read", Err: errors.New("connection reset by peer")}
+
+	tests := []struct {
+		name   string
+		method string
+		err    error
+		want   bool
+	}{
+		{"GET 500", http.MethodGet, &apiError{StatusCode: 500}, true},
+		{"GET 503", http.MethodGet, &apiError{StatusCode: 503}, true},
+		{"GET 429", http.MethodGet, &apiError{StatusCode: 429}, true},
+		{"GET 404", http.MethodGet, &apiError{StatusCode: 404}, false},
+		{"GET 400", http.MethodGet, &apiError{StatusCode: 400}, false},
+		{"PUT 502", http.MethodPut, &apiError{StatusCode: 502}, true},
+		{"POST 500 is not repeated", http.MethodPost, &apiError{StatusCode: 500}, false},
+		{"GET dial error", http.MethodGet, dialErr, true},
+		{"GET read error", http.MethodGet, readErr, true},
+		{"POST dial error", http.MethodPost, dialErr, true},
+		{"POST read error is not repeated", http.MethodPost, readErr, false},
+		{"unauthorized", http.MethodGet, errUnauthorized, false},
+		{"canceled", http.MethodGet, context.Canceled, false},
+		{"deadline exceeded", http.MethodGet, context.DeadlineExceeded, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRetryable(tt.method, tt.err); got != tt.want {
+				t.Errorf("isRetryable(%s, %v) = %v, want %v", tt.method, tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRetryDelay(t *testing.T) {
+	config := &Config{RetryDelay: time.Second}
+
+	tests := []struct {
+		name       string
+		config     *Config
+		attempt    int
+		retryAfter time.Duration
+		want       time.Duration
+	}{
+		{"first attempt", config, 0, 0, time.Second},
+		{"doubles", config, 1, 0, 2 * time.Second},
+		{"doubles again", config, 2, 0, 4 * time.Second},
+		{"capped", config, 20, 0, maxRetryDelay},
+		{"no overflow", config, 64, 0, maxRetryDelay},
+		{"zero delay falls back to the default", &Config{}, 0, 0, defaultRetryDelay},
+		{"Retry-After wins", config, 3, 7 * time.Second, 7 * time.Second},
+		{"Retry-After is capped too", config, 0, time.Hour, maxRetryDelay},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := retryDelay(tt.config, tt.attempt, tt.retryAfter); got != tt.want {
+				t.Errorf("retryDelay(attempt=%d, retryAfter=%s) = %s, want %s",
+					tt.attempt, tt.retryAfter, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	tests := []struct {
+		value string
+		want  time.Duration
+	}{
+		{"", 0},
+		{"5", 5 * time.Second},
+		{" 12 ", 12 * time.Second},
+		{"0", 0},
+		{"-1", 0},
+		{"Wed, 21 Oct 2015 07:28:00 GMT", 0},
+		{"nonsense", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			if got := parseRetryAfter(tt.value); got != tt.want {
+				t.Errorf("parseRetryAfter(%q) = %s, want %s", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDoRequestRetries covers issue #145 end-to-end against a server that fails
+// a fixed number of times before succeeding.
+func TestDoRequestRetries(t *testing.T) {
+	tests := []struct {
+		name         string
+		method       string
+		failures     int
+		failStatus   int
+		retries      int
+		wantAttempts int
+		wantErr      bool
+	}{
+		{"GET recovers from 503", http.MethodGet, 2, 503, 2, 3, false},
+		{"GET gives up after the last retry", http.MethodGet, 5, 503, 2, 3, true},
+		{"GET does not retry 404", http.MethodGet, 5, 404, 2, 1, true},
+		{"POST does not retry 503", http.MethodPost, 5, 503, 2, 1, true},
+		{"no retries configured", http.MethodGet, 1, 500, 0, 1, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var attempts int
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				attempts++
+				if attempts <= tt.failures {
+					w.WriteHeader(tt.failStatus)
+					return
+				}
+				if _, err := w.Write([]byte(`{"ok":true}`)); err != nil {
+					t.Errorf("write response: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			config := &Config{
+				PrivateToken: "test-token",
+				ProjectID:    123,
+				GitLabURL:    server.URL,
+				Retries:      tt.retries,
+				RetryDelay:   time.Millisecond,
+			}
+
+			var reqBody any
+			if tt.method == http.MethodPost {
+				reqBody = map[string]string{"title": "x"}
+			}
+
+			_, err := doRequest(context.Background(), server.Client(), config, tt.method, "projects/123", reqBody)
+
+			if tt.wantErr && err == nil {
+				t.Error("expected an error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if attempts != tt.wantAttempts {
+				t.Errorf("attempts = %d, want %d", attempts, tt.wantAttempts)
+			}
+		})
+	}
+}
+
+// TestDoRequestRespectsRetryAfter checks that a 429 carrying Retry-After waits
+// for the interval GitLab asked for rather than the configured backoff.
+func TestDoRequestRespectsRetryAfter(t *testing.T) {
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts++
+		if attempts == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		if _, err := w.Write([]byte(`{}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	config := &Config{
+		PrivateToken: "test-token",
+		ProjectID:    123,
+		GitLabURL:    server.URL,
+		Retries:      1,
+		RetryDelay:   time.Millisecond, // far shorter than the Retry-After
+	}
+
+	start := time.Now()
+	if _, err := doRequest(context.Background(), server.Client(), config,
+		http.MethodGet, "projects/123", nil); err != nil {
+		t.Fatalf("doRequest() error = %v", err)
+	}
+	elapsed := time.Since(start)
+
+	if attempts != 2 {
+		t.Errorf("attempts = %d, want 2", attempts)
+	}
+	if elapsed < time.Second {
+		t.Errorf("waited %s, expected at least the 1s from Retry-After", elapsed)
+	}
+}
+
+// TestDoRequestRetrySendsBodyAgain guards against the reader being consumed by
+// the first attempt: a retried PUT must send the same payload.
+func TestDoRequestRetrySendsBodyAgain(t *testing.T) {
+	var bodies []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		bodies = append(bodies, string(body))
+		if len(bodies) == 1 {
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		if _, werr := w.Write([]byte(`{}`)); werr != nil {
+			t.Errorf("write response: %v", werr)
+		}
+	}))
+	defer server.Close()
+
+	config := &Config{
+		PrivateToken: "test-token",
+		ProjectID:    123,
+		GitLabURL:    server.URL,
+		Retries:      1,
+		RetryDelay:   time.Millisecond,
+	}
+
+	if _, err := doRequest(context.Background(), server.Client(), config,
+		http.MethodPut, "projects/123/merge_requests/1", map[string]string{"title": "x"}); err != nil {
+		t.Fatalf("doRequest() error = %v", err)
+	}
+
+	if len(bodies) != 2 {
+		t.Fatalf("got %d attempts, want 2", len(bodies))
+	}
+	if bodies[0] != bodies[1] {
+		t.Errorf("retry sent %q, first attempt sent %q", bodies[1], bodies[0])
+	}
+}
+
+// TestSleepRespectsContext checks that a canceled context ends the backoff wait
+// immediately instead of blocking for the full delay.
+func TestSleepRespectsContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	err := sleep(ctx, time.Hour)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("sleep returned after %s, expected it to be immediate", elapsed)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -2314,16 +2314,72 @@ func TestIsRetryable(t *testing.T) {
 		{"POST dial error", http.MethodPost, dialErr, true},
 		{"POST read error is not repeated", http.MethodPost, readErr, false},
 		{"unauthorized", http.MethodGet, errUnauthorized, false},
-		{"canceled", http.MethodGet, context.Canceled, false},
-		{"deadline exceeded", http.MethodGet, context.DeadlineExceeded, false},
+		// A --timeout that elapsed surfaces as DeadlineExceeded while the caller's
+		// context is still live: that is a transient failure, so GET repeats it.
+		{"GET request timeout", http.MethodGet, context.DeadlineExceeded, true},
+		{"POST request timeout is not repeated", http.MethodPost, context.DeadlineExceeded, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isRetryable(tt.method, tt.err); got != tt.want {
+			if got := isRetryable(context.Background(), tt.method, tt.err); got != tt.want {
 				t.Errorf("isRetryable(%s, %v) = %v, want %v", tt.method, tt.err, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestIsRetryableStopsOnCancellation checks that a caller who gave up ends the
+// retries, however transient the underlying failure looks.
+func TestIsRetryableStopsOnCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if isRetryable(ctx, http.MethodGet, &apiError{StatusCode: 503}) {
+		t.Error("expected no retry once the caller's context is done")
+	}
+}
+
+// TestDoRequestRetriesRequestTimeout is the end-to-end form of the same rule:
+// a request that outran --timeout is retried, and the retry succeeds.
+func TestDoRequestRetriesRequestTimeout(t *testing.T) {
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts == 1 {
+			// Outlast the client timeout without hanging the test if it is not hit.
+			select {
+			case <-r.Context().Done():
+			case <-time.After(2 * time.Second):
+			}
+			return
+		}
+		if _, err := w.Write([]byte(`{"ok":true}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	config := &Config{
+		PrivateToken: "test-token",
+		ProjectID:    123,
+		GitLabURL:    server.URL,
+		Timeout:      100 * time.Millisecond,
+		Retries:      1,
+		RetryDelay:   time.Millisecond,
+	}
+
+	client := createHTTPClient(config)
+
+	body, err := doRequest(context.Background(), client, config, http.MethodGet, "projects/123", nil)
+	if err != nil {
+		t.Fatalf("doRequest() error = %v", err)
+	}
+	if string(body) != `{"ok":true}` {
+		t.Errorf("body = %q, want %q", string(body), `{"ok":true}`)
+	}
+	if attempts != 2 {
+		t.Errorf("attempts = %d, want 2", attempts)
 	}
 }
 


### PR DESCRIPTION
Closes #146.

> **Stacked on #163** (which is stacked on #161), since all three touch `createHTTPClient`/`doRequest`. Base is `feat/retry-timeout`; this diff shows only the CA work.

## Behaviour

```bash
gitlab-auto-mr --ca-cert /etc/ssl/certs/internal-ca.pem
```

Also `GITLAB_AUTO_MR_CA_CERT`. The certificate is **appended to a copy of the system pool**, not substituted for it — a self-hosted GitLab behind an internal CA is normally reached from a runner that also talks to hosts with public certificates. On Windows, where `x509.SystemCertPool()` returns an error rather than a pool, it falls back to an empty pool so the given CA still works.

## `--insecure` and `--ca-cert` are refused together

The issue said keeping `--insecure` is fine, and it is kept. But accepting both and letting one silently win is the worst outcome: the user thinks they configured a CA while verification is off. `validateConfig` now rejects the pair with a message that says why.

## Consequences worth noting

`createHTTPClient` can now fail — reading and parsing the PEM happens there — so it returns `(*http.Client, error)` and `run()` reports it like any other error. Errors name the file: `unable to read CA certificate /path: …` and `no PEM certificate found in /path`, so a mistyped path or a DER file is not mistaken for a TLS handshake failure.

Adding one branch to `run()` pushed it to cyclomatic complexity 16, over the configured 15. The two `--create-only`/`--update-mr` precondition guards moved into `checkMRMode` — they read as one unit anyway.

## Tests

`TestCACert` runs against a real `httptest.NewTLSServer`, writing the certificate it presents to a temp PEM:

- **trusted with `--ca-cert`** — `getProject` succeeds over TLS against that server;
- **rejected without it** — the same call fails, which is what makes the first case meaningful;
- **missing file** and **file without a certificate** — each produces its own error.

`TestCACertWithInsecureRejected` covers the mutual exclusion.

```
$ go test -race ./...
ok  	gitlab-auto-mr	2.960s
$ golangci-lint run
0 issues.
```