### PR TITLE
fix: create at most one merge request pipeline per commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ create_only:
 | `--update-mr`           |       | Update existing MR (required to update, fail if none exists) | `false`                |
 | `--create-only`         |       | Force create new MR (fail if already exists)   | `false`                |
 | `--auto-merge`          |       | Enable merge when pipeline succeeds (auto-merge) | `false`              |
-| `--trigger-pipeline`    |       | Create a merge request pipeline after the MR is created | `false`         |
+| `--trigger-pipeline`    |       | Create a merge request pipeline for the created or updated MR | `false`   |
+| `--force-pipeline`      |       | With `--trigger-pipeline`, create one even if the commit has one | `false` |
 | `--insecure`            | `-k`  | Skip SSL certificate verification              | `false`                |
 
 ### Merge Request Pipelines
@@ -183,8 +184,9 @@ configuration runs jobs only on `merge_request_event`, those jobs never run for
 the newly created MR — and the branch pipeline that did run may look green while
 having executed none of them.
 
-`--trigger-pipeline` asks GitLab for that pipeline explicitly, right after the MR
-is created:
+`--trigger-pipeline` asks GitLab for that pipeline explicitly, for the MR this
+run created **or updated** — a branch that moved is exactly when the checks are
+worth re-running:
 
 ```yaml
 open_merge_request:
@@ -192,6 +194,21 @@ open_merge_request:
   script:
     - gitlab_auto_mr --target-branch main --trigger-pipeline
 ```
+
+The flag acts at most once per commit. Before creating a pipeline the tool lists
+the MR's existing ones and skips when it finds one for the same head commit,
+reporting the skip so it is visible in the job log:
+
+```
+Merge request pipeline already exists for commit abc123de (ID: 7, status: running): https://gitlab.example.com/p/-/pipelines/7
+Skipping pipeline creation; pass --force-pipeline to create another.
+```
+
+That is what keeps a retried job, a manual re-run, or a later run against the
+same MR from stacking up pipelines for one commit. Use `--force-pipeline` when
+re-running the checks is exactly the point. If the pipeline list cannot be read,
+the tool creates one anyway: a duplicate is a better outcome than checks that
+silently did not run.
 
 Two things to expect:
 

--- a/main.go
+++ b/main.go
@@ -59,6 +59,7 @@ type Config struct {
 	TriggerPipeline    bool
 	Labels             []string
 	MilestoneID        int
+	ForcePipeline      bool
 }
 
 type Project struct {
@@ -75,12 +76,14 @@ type MergeRequest struct {
 	TargetBranch string `json:"target_branch"`
 	State        string `json:"state"`
 	WebURL       string `json:"web_url"`
+	SHA          string `json:"sha"`
 }
 
 type Pipeline struct {
 	ID     int    `json:"id"`
 	Status string `json:"status"`
 	WebURL string `json:"web_url"`
+	SHA    string `json:"sha"`
 }
 
 type Issue struct {
@@ -181,8 +184,10 @@ func parseFlags() (*Config, error) {
 	flag.BoolVar(&config.UpdateMR, "update-mr", false, "Update existing MR instead of creating new one")
 	flag.BoolVar(&config.CreateOnly, "create-only", false, "Only create new MR, fail if MR already exists")
 	flag.BoolVar(&config.AutoMerge, "auto-merge", false, "Enable merge when pipeline succeeds (auto-merge)")
+	flag.BoolVar(&config.ForcePipeline, "force-pipeline", false,
+		"With --trigger-pipeline, create a pipeline even if one exists for the same commit")
 	flag.BoolVar(&config.TriggerPipeline, "trigger-pipeline", false,
-		"Create a merge request pipeline after the MR is created")
+		"Create a merge request pipeline for the MR, whether it was created or updated")
 	flag.BoolVar(&showVersion, "version", false, "Show version information and exit")
 	flag.BoolVar(&showVersion, "v", false, "Show version information and exit (short)")
 
@@ -239,6 +244,10 @@ func isDraftPrefix(prefix string) bool {
 }
 
 func validateConfig(config *Config) error {
+	if config.ForcePipeline && !config.TriggerPipeline {
+		return fmt.Errorf("--force-pipeline has no effect without --trigger-pipeline")
+	}
+
 	if config.AutoMerge && config.MRExists {
 		return fmt.Errorf("--auto-merge cannot be used with --mr-exists (dry run mode)")
 	}
@@ -297,6 +306,38 @@ func run(config *Config) error {
 		return nil
 	}
 
+	if err := checkMRMode(config, existingMR); err != nil {
+		return err
+	}
+
+	title := getMRTitle(config.CommitPrefix, config.Title, config.SourceBranch)
+	description := getDescriptionData(config.Description)
+
+	mr, err := handleMR(client, config, existingMR, title, description)
+	if err != nil {
+		return err
+	}
+	if mr == nil {
+		// Defensive: every handleMR branch returns an MR on success.
+		mr = &MergeRequest{}
+	}
+
+	if config.TriggerPipeline {
+		if err := triggerMRPipeline(client, config, mr); err != nil {
+			return fmt.Errorf("failed to trigger merge request pipeline: %v", err)
+		}
+	}
+
+	if config.AutoMerge {
+		return enableAutoMerge(client, config, mr.IID)
+	}
+
+	return nil
+}
+
+// checkMRMode rejects the two combinations where the mode the user asked for
+// contradicts what is actually on the server.
+func checkMRMode(config *Config, existingMR *MergeRequest) error {
 	if config.CreateOnly && existingMR != nil {
 		return fmt.Errorf(
 			"merge request already exists for this branch %s to %s, "+
@@ -313,31 +354,13 @@ func run(config *Config) error {
 		)
 	}
 
-	title := getMRTitle(config.CommitPrefix, config.Title, config.SourceBranch)
-	description := getDescriptionData(config.Description)
-
-	mrIID, err := handleMR(client, config, existingMR, title, description)
-	if err != nil {
-		return err
-	}
-
-	if config.TriggerPipeline {
-		if err := triggerMRPipeline(client, config, mrIID); err != nil {
-			return fmt.Errorf("failed to trigger merge request pipeline: %v", err)
-		}
-	}
-
-	if config.AutoMerge {
-		return enableAutoMerge(client, config, mrIID)
-	}
-
 	return nil
 }
 
 func handleMR(
 	client *http.Client, config *Config,
 	existingMR *MergeRequest, title, description string,
-) (int, error) {
+) (*MergeRequest, error) {
 	switch {
 	case existingMR != nil && !config.UpdateMR:
 		if config.AutoMerge {
@@ -353,7 +376,7 @@ func handleMR(
 			)
 		}
 		printMRURL(existingMR)
-		return existingMR.IID, nil
+		return existingMR, nil
 
 	case existingMR != nil:
 		return handleUpdateMR(client, config, existingMR, title, description)
@@ -366,7 +389,7 @@ func handleMR(
 func handleUpdateMR(
 	client *http.Client, config *Config,
 	existingMR *MergeRequest, title, description string,
-) (int, error) {
+) (*MergeRequest, error) {
 	updateRequest := &MRUpdateRequest{
 		Title:              title,
 		Description:        description,
@@ -380,18 +403,18 @@ func handleUpdateMR(
 	updateRequest.MilestoneID, updateRequest.Labels = resolveMRMetadata(client, config)
 
 	if err := updateMR(client, config, existingMR.IID, updateRequest); err != nil {
-		return 0, fmt.Errorf("failed to update MR: %v", err)
+		return nil, fmt.Errorf("failed to update MR: %v", err)
 	}
 
 	fmt.Printf("Updated existing MR %s (IID: %d)\n", title, existingMR.IID)
 	printMRURL(existingMR)
-	return existingMR.IID, nil
+	return existingMR, nil
 }
 
 func handleCreateMR(
 	client *http.Client, config *Config,
 	title, description string,
-) (int, error) {
+) (*MergeRequest, error) {
 	mrRequest := &MRCreateRequest{
 		SourceBranch:       config.SourceBranch,
 		TargetBranch:       config.TargetBranch,
@@ -408,12 +431,12 @@ func handleCreateMR(
 
 	createdMR, err := createMR(client, config, mrRequest)
 	if err != nil {
-		return 0, fmt.Errorf("failed to create MR: %v", err)
+		return nil, fmt.Errorf("failed to create MR: %v", err)
 	}
 
 	fmt.Printf("Created a new MR %s, assigned to you.\n", title)
 	printMRURL(createdMR)
-	return createdMR.IID, nil
+	return createdMR, nil
 }
 
 // resolveMRMetadata determines the milestone and labels for the MR, combining
@@ -505,15 +528,36 @@ func enableAutoMerge(client *http.Client, config *Config, mrIID int) error {
 // for a commit that already has a branch pipeline. A CI configuration whose
 // jobs run only on `merge_request_event` would therefore never see the MR, and
 // the missing checks are easy to mistake for passing ones.
-func triggerMRPipeline(client *http.Client, config *Config, mrIID int) error {
-	if mrIID == 0 {
+//
+// The call runs for updated MRs as well as new ones, because a moved branch is
+// exactly when the checks are worth re-running. To keep that from producing a
+// pipeline per job run, an existing pipeline for the same commit is left alone
+// unless --force-pipeline says otherwise.
+func triggerMRPipeline(client *http.Client, config *Config, mr *MergeRequest) error {
+	if mr == nil || mr.IID == 0 {
 		fmt.Println("Warning: could not determine MR IID, skipping pipeline trigger")
 		return nil
 	}
 
+	if !config.ForcePipeline {
+		existing, err := findPipelineForSHA(client, config, mr)
+		if err != nil {
+			// Not being able to list pipelines is no reason to skip creating one;
+			// the worst case is the duplicate this check exists to avoid.
+			fmt.Fprintf(os.Stderr, "Warning: could not check for existing pipelines: %v\n", err)
+		} else if existing != nil {
+			fmt.Printf(
+				"Merge request pipeline already exists for commit %s (ID: %d, status: %s)%s\n",
+				shortSHA(mr.SHA), existing.ID, existing.Status, urlSuffix(existing.WebURL),
+			)
+			fmt.Println("Skipping pipeline creation; pass --force-pipeline to create another.")
+			return nil
+		}
+	}
+
 	apiURL := fmt.Sprintf(
 		"%s/api/v4/projects/%d/merge_requests/%d/pipelines",
-		config.GitLabURL, config.ProjectID, mrIID,
+		config.GitLabURL, config.ProjectID, mr.IID,
 	)
 
 	req, err := http.NewRequest("POST", apiURL, http.NoBody)
@@ -539,14 +583,10 @@ func triggerMRPipeline(client *http.Client, config *Config, mrIID int) error {
 			fmt.Printf("Warning: merge request pipeline created but response could not be read: %v\n", err)
 			return nil
 		}
-		if pipeline.WebURL != "" {
-			fmt.Printf(
-				"Merge request pipeline created (ID: %d, status: %s): %s\n",
-				pipeline.ID, pipeline.Status, pipeline.WebURL,
-			)
-			return nil
-		}
-		fmt.Printf("Merge request pipeline created (ID: %d, status: %s)\n", pipeline.ID, pipeline.Status)
+		fmt.Printf(
+			"Merge request pipeline created (ID: %d, status: %s)%s\n",
+			pipeline.ID, pipeline.Status, urlSuffix(pipeline.WebURL),
+		)
 		return nil
 	case 401:
 		return fmt.Errorf("unauthorized access, check your access token permissions")
@@ -566,6 +606,71 @@ func triggerMRPipeline(client *http.Client, config *Config, mrIID int) error {
 		respBody, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
 	}
+}
+
+// findPipelineForSHA returns the MR's existing pipeline for its head commit, or
+// nil when there is none.
+//
+// With an unknown head SHA there is nothing to compare against, so it reports
+// no match and the caller creates a pipeline: a duplicate is a better outcome
+// than silently skipping the checks.
+func findPipelineForSHA(client *http.Client, config *Config, mr *MergeRequest) (*Pipeline, error) {
+	if mr.SHA == "" {
+		return nil, nil
+	}
+
+	apiURL := fmt.Sprintf(
+		"%s/api/v4/projects/%d/merge_requests/%d/pipelines",
+		config.GitLabURL, config.ProjectID, mr.IID,
+	)
+
+	req, err := http.NewRequest("GET", apiURL, http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("PRIVATE-TOKEN", config.PrivateToken)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var pipelines []Pipeline
+	if err := json.NewDecoder(resp.Body).Decode(&pipelines); err != nil {
+		return nil, err
+	}
+
+	for i := range pipelines {
+		if pipelines[i].SHA == mr.SHA {
+			return &pipelines[i], nil
+		}
+	}
+
+	return nil, nil
+}
+
+// shortSHA abbreviates a commit hash for log output, the way git does.
+func shortSHA(sha string) string {
+	const shortLen = 8
+	if len(sha) <= shortLen {
+		return sha
+	}
+	return sha[:shortLen]
+}
+
+// urlSuffix renders ": <url>" when there is a URL, and nothing when there is not.
+func urlSuffix(webURL string) string {
+	if webURL == "" {
+		return ""
+	}
+	return ": " + webURL
 }
 
 func createHTTPClient(insecure bool) *http.Client {

--- a/main_test.go
+++ b/main_test.go
@@ -1922,6 +1922,209 @@ func TestPrintMRURL(t *testing.T) {
 	}
 }
 
+// pipelineServer mocks the two pipeline endpoints and records how often the MR
+// pipeline was created. existingSHA, when non-empty, is the SHA of a pipeline
+// GitLab already has for the MR.
+func pipelineServer(t *testing.T, existingSHA string, listStatus int) (*httptest.Server, *int) {
+	t.Helper()
+
+	created := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v4/projects/123/merge_requests/42/pipelines" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.Method {
+		case http.MethodGet:
+			if listStatus != 0 && listStatus != http.StatusOK {
+				w.WriteHeader(listStatus)
+				return
+			}
+			body := "[]"
+			if existingSHA != "" {
+				body = `[{"id":7,"status":"running","sha":"` + existingSHA +
+					`","web_url":"https://gitlab.example.com/p/-/pipelines/7"}]`
+			}
+			if _, err := w.Write([]byte(body)); err != nil {
+				t.Errorf("write pipeline list: %v", err)
+			}
+		case http.MethodPost:
+			created++
+			w.WriteHeader(http.StatusCreated)
+			if _, err := w.Write([]byte(`{"id":9,"status":"created"}`)); err != nil {
+				t.Errorf("write created pipeline: %v", err)
+			}
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+
+	return server, &created
+}
+
+// TestTriggerMRPipelineDeduplicates covers issue #151: a pipeline is not created
+// again for a commit that already has one, unless --force-pipeline is given.
+func TestTriggerMRPipelineDeduplicates(t *testing.T) {
+	const headSHA = "abc123def456"
+
+	tests := []struct {
+		name        string
+		existingSHA string
+		mrSHA       string
+		force       bool
+		listStatus  int
+		wantCreated int
+	}{
+		{
+			name:        "skips when a pipeline exists for the head commit",
+			existingSHA: headSHA,
+			mrSHA:       headSHA,
+			wantCreated: 0,
+		},
+		{
+			name:        "creates when the existing pipeline is for an older commit",
+			existingSHA: "0000000000",
+			mrSHA:       headSHA,
+			wantCreated: 1,
+		},
+		{
+			name:        "creates when the MR has no pipelines",
+			mrSHA:       headSHA,
+			wantCreated: 1,
+		},
+		{
+			name:        "--force-pipeline creates anyway",
+			existingSHA: headSHA,
+			mrSHA:       headSHA,
+			force:       true,
+			wantCreated: 1,
+		},
+		{
+			name:        "creates when the head SHA is unknown",
+			existingSHA: headSHA,
+			mrSHA:       "",
+			wantCreated: 1,
+		},
+		{
+			name:        "creates when the pipeline list cannot be read",
+			existingSHA: headSHA,
+			mrSHA:       headSHA,
+			listStatus:  http.StatusInternalServerError,
+			wantCreated: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, created := pipelineServer(t, tt.existingSHA, tt.listStatus)
+			defer server.Close()
+
+			config := &Config{
+				PrivateToken:    "test-token",
+				ProjectID:       123,
+				GitLabURL:       server.URL,
+				TriggerPipeline: true,
+				ForcePipeline:   tt.force,
+			}
+
+			err := triggerMRPipeline(server.Client(), config, &MergeRequest{IID: 42, SHA: tt.mrSHA})
+			if err != nil {
+				t.Fatalf("triggerMRPipeline() error = %v", err)
+			}
+			if *created != tt.wantCreated {
+				t.Errorf("pipelines created = %d, want %d", *created, tt.wantCreated)
+			}
+		})
+	}
+}
+
+// TestRunTriggersPipelineOnUpdate covers issue #150: updating an existing MR
+// triggers a pipeline too, since the branch has moved. The MR carries a SHA
+// that has no pipeline yet, which is the case where a new one is wanted.
+func TestRunTriggersPipelineOnUpdate(t *testing.T) {
+	created := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v4/projects/123" && r.Method == http.MethodGet:
+			if err := json.NewEncoder(w).Encode(Project{ID: 123, DefaultBranch: "main"}); err != nil {
+				t.Errorf("encode project: %v", err)
+			}
+		case r.URL.Path == "/api/v4/projects/123/merge_requests" && r.Method == http.MethodGet:
+			if _, err := w.Write([]byte(`[{"id":1,"iid":42,"title":"Old","sha":"newsha"}]`)); err != nil {
+				t.Errorf("write MR list: %v", err)
+			}
+		case r.URL.Path == "/api/v4/projects/123/merge_requests/42" && r.Method == http.MethodPut:
+			if _, err := w.Write([]byte(`{"id":1,"iid":42}`)); err != nil {
+				t.Errorf("write update response: %v", err)
+			}
+		case r.URL.Path == "/api/v4/projects/123/merge_requests/42/pipelines" && r.Method == http.MethodGet:
+			if _, err := w.Write([]byte(`[{"id":7,"status":"success","sha":"oldsha"}]`)); err != nil {
+				t.Errorf("write pipeline list: %v", err)
+			}
+		case r.URL.Path == "/api/v4/projects/123/merge_requests/42/pipelines" && r.Method == http.MethodPost:
+			created++
+			w.WriteHeader(http.StatusCreated)
+			if _, err := w.Write([]byte(`{"id":9,"status":"created"}`)); err != nil {
+				t.Errorf("write created pipeline: %v", err)
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	config := &Config{
+		PrivateToken:    "test-token",
+		SourceBranch:    "feature/test",
+		ProjectID:       123,
+		GitLabURL:       server.URL,
+		UserIDs:         []int{1},
+		TargetBranch:    "main",
+		UpdateMR:        true,
+		TriggerPipeline: true,
+	}
+
+	if err := run(config); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if created != 1 {
+		t.Errorf("pipelines created on update = %d, want 1", created)
+	}
+}
+
+// TestForcePipelineRequiresTriggerPipeline checks the flag is refused on its
+// own rather than silently doing nothing.
+func TestForcePipelineRequiresTriggerPipeline(t *testing.T) {
+	err := validateConfig(&Config{ForcePipeline: true})
+	if err == nil {
+		t.Fatal("expected an error for --force-pipeline without --trigger-pipeline")
+	}
+	if !strings.Contains(err.Error(), "--force-pipeline has no effect without --trigger-pipeline") {
+		t.Errorf("error = %v", err)
+	}
+}
+
+func TestShortSHA(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"", ""},
+		{"abc", "abc"},
+		{"abcdef12", "abcdef12"},
+		{"abcdef1234567890", "abcdef12"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := shortSHA(tt.in); got != tt.want {
+				t.Errorf("shortSHA(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 // resetFlagSet replaces the package-level flag.CommandLine with a fresh FlagSet
 // using ContinueOnError. parseFlags re-registers every flag on flag.CommandLine,
 // so without a reset the second subtest would panic with "flag redefined".
@@ -2257,7 +2460,7 @@ func TestTriggerMRPipeline(t *testing.T) {
 		PrivateToken: "test-token",
 	}
 
-	if err := triggerMRPipeline(client, config, 42); err != nil {
+	if err := triggerMRPipeline(client, config, &MergeRequest{IID: 42}); err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
 }
@@ -2276,7 +2479,7 @@ func TestTriggerMRPipelineZeroIID(t *testing.T) {
 		PrivateToken: "test-token",
 	}
 
-	if err := triggerMRPipeline(client, config, 0); err != nil {
+	if err := triggerMRPipeline(client, config, &MergeRequest{}); err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
 }
@@ -2309,7 +2512,7 @@ func TestTriggerMRPipelineErrors(t *testing.T) {
 				PrivateToken: "test-token",
 			}
 
-			err := triggerMRPipeline(client, config, 42)
+			err := triggerMRPipeline(client, config, &MergeRequest{IID: 42})
 			if err == nil {
 				t.Fatal("Expected an error, got nil")
 			}
@@ -2336,7 +2539,7 @@ func TestTriggerMRPipelineUnreadableBody(t *testing.T) {
 		PrivateToken: "test-token",
 	}
 
-	if err := triggerMRPipeline(client, config, 42); err != nil {
+	if err := triggerMRPipeline(client, config, &MergeRequest{IID: 42}); err != nil {
 		t.Errorf("Expected no error for an unreadable body, got %v", err)
 	}
 }


### PR DESCRIPTION
Closes #151, closes #150 — the issues asked to decide them together, and they resolve each other.

## The duplicate (#151)

`triggerMRPipeline` POSTed unconditionally, so every execution produced another merge request pipeline for the same MR: on a retried job, on a manual re-run, and on any later run against an existing MR.

Now the MR's pipelines are listed first, and the run skips when one already exists for the head commit:

```
Merge request pipeline already exists for commit abc123de (ID: 7, status: running): https://gitlab.example.com/p/-/pipelines/7
Skipping pipeline creation; pass --force-pipeline to create another.
```

The skip is printed rather than silent, so the behaviour is visible in the job log. `--force-pipeline` is the escape hatch the issue asked for, and it is rejected without `--trigger-pipeline` rather than quietly doing nothing.

**Failing to list is not a reason to skip.** If the list call errors, the tool warns and creates a pipeline anyway — a duplicate is a better outcome than checks that silently did not run. Same when the head SHA is unknown: nothing to compare against, so it creates.

## The update question (#150)

**Decision: trigger on update too**, and the README now says so instead of "after the MR is created".

Taken alone, the case against was that later pushes to a branch with an open MR already produce a merge request pipeline of their own, making an explicit trigger redundant or duplicated. But that argument is exactly what the per-commit check above answers: if GitLab already made one for this commit, this run skips. What is left is the case the flag exists for — a branch that moved and whose checks are worth re-running — with the redundancy removed rather than traded for a missing pipeline.

Keeping the flag's meaning simple ("this run should have a pipeline") also matches how it reads at a call site in `.gitlab-ci.yml`.

## Implementation note

`handleMR` returns the `*MergeRequest` instead of just its IID, because the comparison needs the head SHA. It is already in the create response and in the list response `getExistingMR` reads, so no extra API call — `MergeRequest` and `Pipeline` just gained their `sha` fields.

Adding a branch to `run()` pushed it to complexity 16, over the configured 15; the two `--create-only`/`--update-mr` precondition guards moved into `checkMRMode`, which they already formed in practice.

## Tests

- `TestTriggerMRPipelineDeduplicates` — six cases counting actual POSTs: existing pipeline for the head commit (0 created), existing pipeline for an older commit (1), no pipelines (1), `--force-pipeline` (1), unknown head SHA (1), unreadable pipeline list (1).
- `TestRunTriggersPipelineOnUpdate` — through `run()` with `--update-mr --trigger-pipeline`, asserting the update path does trigger.
- `TestForcePipelineRequiresTriggerPipeline`, `TestShortSHA`.

The existing `triggerMRPipeline` tests from #143 pass unchanged apart from taking an MR instead of an IID — and, since their MRs carry no SHA, they double as coverage for the unknown-SHA fallback.

```
$ go test -race ./...
ok  	gitlab-auto-mr	1.854s
$ golangci-lint run
0 issues.
```

Conflicts with #161 in `triggerMRPipeline`; mechanical to resolve whichever lands second.
