### PR TITLE
feat: retry transient GitLab failures, make the timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,9 @@ What gets retried depends on what a repeat could do:
 timeout could open a second merge request. A failure to dial is safe to repeat,
 because the request demonstrably never reached GitLab.
 
+A request that outran `--timeout` counts as a network error here, so a hung GET
+is retried. Ctrl-C is not: once the caller has given up, nothing is retried.
+
 A `Retry-After` header — which GitLab sends when rate limiting — takes
 precedence over the backoff, capped at 30s. 4xx answers other than 429 are never
 retried: they are real answers, and repeating them only delays the error.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ create_only:
   `--target-branch`/`-t`; when neither is set, the project's default branch is used.
 - `GITLAB_AUTO_MR_LABELS` - Labels for the MR (comma-separated). Overridden by `--label`.
 - `GITLAB_AUTO_MR_MILESTONE` - Milestone ID for the MR. Overridden by `--milestone`.
+- `GITLAB_AUTO_MR_TIMEOUT` - Timeout for a single API request (default `30s`)
+- `GITLAB_AUTO_MR_RETRIES` - Retries for transient failures (default `2`)
+- `GITLAB_AUTO_MR_RETRY_DELAY` - Delay before the first retry (default `1s`)
 
 ### CLI Options
 
@@ -178,6 +181,10 @@ create_only:
 | `--auto-merge`          |       | Enable merge when pipeline succeeds (auto-merge) | `false`              |
 | `--trigger-pipeline`    |       | Create a merge request pipeline for the created or updated MR | `false`   |
 | `--force-pipeline`      |       | With `--trigger-pipeline`, create one even if the commit has one | `false` |
+| `--trigger-pipeline`    |       | Create a merge request pipeline after the MR is created | `false`         |
+| `--timeout`             |       | Timeout for a single API request               | `30s`                  |
+| `--retries`             |       | Retries for transient failures (5xx, 429, network) | `2`                |
+| `--retry-delay`         |       | Delay before the first retry, doubled each time | `1s`                  |
 | `--insecure`            | `-k`  | Skip SSL certificate verification              | `false`                |
 
 ### Merge Request Pipelines
@@ -233,6 +240,28 @@ Two things to expect:
   role on the project. A `CI_JOB_TOKEN` cannot be used: the Merge Requests API
   is read-only for job tokens, so it can neither create the MR nor request a
   pipeline for it.
+
+## Retries
+
+Self-hosted GitLab returns 502/503 during restarts and upgrades, and CI runners
+hit transient network errors. By default the tool retries such a failure twice,
+waiting 1s and then 2s, so a job does not fail for a reason that a re-run would
+have fixed anyway. `--retries 0` turns it off.
+
+What gets retried depends on what a repeat could do:
+
+| Request | Retried on 5xx / 429 | Retried on a network error |
+| --- | --- | --- |
+| `GET`, `PUT` | yes | yes |
+| `POST` | no | only if the connection was never established |
+
+`POST /merge_requests` is the reason for the asymmetry: retrying it after a
+timeout could open a second merge request. A failure to dial is safe to repeat,
+because the request demonstrably never reached GitLab.
+
+A `Retry-After` header — which GitLab sends when rate limiting — takes
+precedence over the backoff, capped at 30s. 4xx answers other than 429 are never
+retried: they are real answers, and repeating them only delays the error.
 
 ## Building
 

--- a/main.go
+++ b/main.go
@@ -769,7 +769,7 @@ func doRequest(
 			return respBody, nil
 		}
 
-		if attempt >= config.Retries || !isRetryable(method, err) {
+		if attempt >= config.Retries || !isRetryable(ctx, method, err) {
 			return nil, err
 		}
 
@@ -834,9 +834,16 @@ func sendRequest(
 // same change twice. POST is not — retrying POST /merge_requests after a
 // timeout could open a second MR — so it is repeated only when the request
 // demonstrably never reached GitLab, which is what a dial failure means.
-func isRetryable(method string, err error) bool {
-	if errors.Is(err, errUnauthorized) || errors.Is(err, context.Canceled) ||
-		errors.Is(err, context.DeadlineExceeded) {
+//
+// Whether the caller gave up is read from ctx, not from err. A --timeout that
+// elapsed also surfaces as context.DeadlineExceeded, and that one is a
+// transient failure worth repeating — the very case retries exist for.
+func isRetryable(ctx context.Context, method string, err error) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+
+	if errors.Is(err, errUnauthorized) {
 		return false
 	}
 

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -37,6 +38,15 @@ const (
 // pipelineSourceMergeRequest is the `source` GitLab reports for a merge request
 // pipeline, as opposed to the `push` of an ordinary branch pipeline.
 const pipelineSourceMergeRequest = "merge_request_event"
+
+// Defaults for the HTTP behavior. They are applied where they are used, not
+// only in parseFlags, so a zero-valued Config still behaves like the tool did
+// before these flags existed.
+const (
+	defaultTimeout    = 30 * time.Second
+	defaultRetryDelay = time.Second
+	maxRetryDelay     = 30 * time.Second
+)
 
 // errShowVersion is a sentinel error returned by parseFlags when --version has
 // been handled (version printed to stdout). Callers should treat it as a clean
@@ -67,6 +77,9 @@ type Config struct {
 	Labels             []string
 	MilestoneID        int
 	ForcePipeline      bool
+	Timeout            time.Duration
+	Retries            int
+	RetryDelay         time.Duration
 }
 
 type Project struct {
@@ -204,6 +217,13 @@ func parseFlags() (*Config, error) {
 		"With --trigger-pipeline, create a pipeline even if one exists for the same commit")
 	flag.BoolVar(&config.TriggerPipeline, "trigger-pipeline", false,
 		"Create a merge request pipeline for the MR, whether it was created or updated")
+	flag.DurationVar(&config.Timeout, "timeout", getEnvDuration("GITLAB_AUTO_MR_TIMEOUT", defaultTimeout),
+		"Timeout for a single GitLab API request")
+	flag.IntVar(&config.Retries, "retries", getEnvInt("GITLAB_AUTO_MR_RETRIES", 2),
+		"Retries for transient GitLab failures (network errors, 5xx, 429)")
+	flag.DurationVar(&config.RetryDelay, "retry-delay",
+		getEnvDuration("GITLAB_AUTO_MR_RETRY_DELAY", defaultRetryDelay),
+		"Delay before the first retry, doubled on each further attempt")
 	flag.BoolVar(&showVersion, "version", false, "Show version information and exit")
 	flag.BoolVar(&showVersion, "v", false, "Show version information and exit (short)")
 
@@ -229,6 +249,16 @@ func parseFlags() (*Config, error) {
 	}
 	if userIDsStr == "" {
 		return nil, fmt.Errorf("--user-id is required")
+	}
+
+	if config.Timeout <= 0 {
+		return nil, fmt.Errorf("--timeout must be positive, got %s", config.Timeout)
+	}
+	if config.Retries < 0 {
+		return nil, fmt.Errorf("--retries must not be negative, got %d", config.Retries)
+	}
+	if config.RetryDelay < 0 {
+		return nil, fmt.Errorf("--retry-delay must not be negative, got %s", config.RetryDelay)
 	}
 
 	// Parse user IDs
@@ -297,7 +327,7 @@ func run(ctx context.Context, config *Config) error {
 		return err
 	}
 
-	client := createHTTPClient(config.Insecure)
+	client := createHTTPClient(config)
 
 	project, err := getProject(ctx, client, config)
 	if err != nil {
@@ -666,12 +696,17 @@ func urlSuffix(webURL string) string {
 	return ": " + webURL
 }
 
-func createHTTPClient(insecure bool) *http.Client {
-	client := &http.Client{
-		Timeout: 30 * time.Second,
+func createHTTPClient(config *Config) *http.Client {
+	timeout := config.Timeout
+	if timeout <= 0 {
+		timeout = defaultTimeout
 	}
 
-	if insecure {
+	client := &http.Client{
+		Timeout: timeout,
+	}
+
+	if config.Insecure {
 		// #nosec G402 -- certificate verification is disabled only at the user's
 		// explicit request, via --insecure/-k.
 		tr := &http.Transport{
@@ -705,7 +740,8 @@ func (e *apiError) Error() string {
 // re-worded per function.
 var errUnauthorized = errors.New("unauthorized access, check your access token is valid and has the api scope")
 
-// doRequest performs one GitLab API call and returns the raw response body.
+// doRequest performs one GitLab API call and returns the raw response body,
+// retrying the attempt when the failure looks transient.
 //
 // path is relative to /api/v4 and must already be escaped. body, when non-nil,
 // is sent as JSON. Any 2xx is success; 401 yields errUnauthorized and every
@@ -719,45 +755,172 @@ func doRequest(
 ) ([]byte, error) {
 	apiURL := fmt.Sprintf("%s/api/v4/%s", config.GitLabURL, path)
 
-	var reader io.Reader = http.NoBody
+	var jsonData []byte
 	if body != nil {
-		jsonData, err := json.Marshal(body)
-		if err != nil {
+		var err error
+		if jsonData, err = json.Marshal(body); err != nil {
 			return nil, err
 		}
-		reader = bytes.NewBuffer(jsonData)
+	}
+
+	for attempt := 0; ; attempt++ {
+		respBody, retryAfter, err := sendRequest(ctx, client, config, method, apiURL, jsonData, body != nil)
+		if err == nil {
+			return respBody, nil
+		}
+
+		if attempt >= config.Retries || !isRetryable(method, err) {
+			return nil, err
+		}
+
+		delay := retryDelay(config, attempt, retryAfter)
+		fmt.Fprintf(os.Stderr, "Warning: %s %s failed (%v), retrying in %s (%d/%d)\n",
+			method, path, err, delay, attempt+1, config.Retries)
+
+		if err := sleep(ctx, delay); err != nil {
+			return nil, err
+		}
+	}
+}
+
+// sendRequest performs a single attempt. The returned duration is the value of
+// a Retry-After header, when GitLab sent one that could be parsed.
+func sendRequest(
+	ctx context.Context, client *http.Client, config *Config,
+	method, apiURL string, jsonData []byte, hasBody bool,
+) ([]byte, time.Duration, error) {
+	var reader io.Reader = http.NoBody
+	if hasBody {
+		reader = bytes.NewReader(jsonData)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, method, apiURL, reader)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	req.Header.Set("PRIVATE-TOKEN", config.PrivateToken)
-	if body != nil {
+	if hasBody {
 		req.Header.Set("Content-Type", "application/json")
 	}
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	defer resp.Body.Close()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, errUnauthorized
+		return nil, 0, errUnauthorized
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, &apiError{StatusCode: resp.StatusCode, Body: string(respBody)}
+		return nil, parseRetryAfter(resp.Header.Get("Retry-After")),
+			&apiError{StatusCode: resp.StatusCode, Body: string(respBody)}
 	}
 
-	return respBody, nil
+	return respBody, 0, nil
+}
+
+// isRetryable decides whether a failed attempt is worth repeating.
+//
+// The rule is about what a repeat could do, not only about what failed. GET and
+// PUT are idempotent, so repeating one is harmless: at worst GitLab applies the
+// same change twice. POST is not — retrying POST /merge_requests after a
+// timeout could open a second MR — so it is repeated only when the request
+// demonstrably never reached GitLab, which is what a dial failure means.
+func isRetryable(method string, err error) bool {
+	if errors.Is(err, errUnauthorized) || errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	var apiErr *apiError
+	if errors.As(err, &apiErr) {
+		// GitLab answered, so the request did reach it: repeating is only safe
+		// for the idempotent verbs.
+		if !isIdempotent(method) {
+			return false
+		}
+		return apiErr.StatusCode >= 500 || apiErr.StatusCode == http.StatusTooManyRequests
+	}
+
+	if isIdempotent(method) {
+		return true
+	}
+
+	return isDialError(err)
+}
+
+func isIdempotent(method string) bool {
+	return method == http.MethodGet || method == http.MethodPut || method == http.MethodHead
+}
+
+// isDialError reports whether the connection was never established, which means
+// the server cannot have seen the request.
+func isDialError(err error) bool {
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return opErr.Op == "dial"
+	}
+	return false
+}
+
+// retryDelay is the exponential backoff, unless GitLab asked for a specific
+// wait via Retry-After — it knows better, and ignoring it on a 429 only earns
+// another one.
+func retryDelay(config *Config, attempt int, retryAfter time.Duration) time.Duration {
+	if retryAfter > 0 {
+		if retryAfter > maxRetryDelay {
+			return maxRetryDelay
+		}
+		return retryAfter
+	}
+
+	base := config.RetryDelay
+	if base <= 0 {
+		base = defaultRetryDelay
+	}
+
+	delay := base << attempt
+	// Shifting past the width of the type wraps; both cases mean "too long".
+	if delay > maxRetryDelay || delay <= 0 {
+		return maxRetryDelay
+	}
+	return delay
+}
+
+// parseRetryAfter reads the delay-seconds form of Retry-After, which is what
+// GitLab sends. The HTTP-date form is ignored rather than guessed at.
+func parseRetryAfter(value string) time.Duration {
+	if value == "" {
+		return 0
+	}
+
+	seconds, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || seconds < 0 {
+		return 0
+	}
+
+	return time.Duration(seconds) * time.Second
+}
+
+// sleep waits for d, or returns early if the context is canceled first.
+func sleep(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func getProject(ctx context.Context, client *http.Client, config *Config) (*Project, error) {
@@ -936,6 +1099,15 @@ func versionInfo() string {
 func getEnv(key, defaultValue string) string {
 	if value := os.Getenv(key); value != "" {
 		return value
+	}
+	return defaultValue
+}
+
+func getEnvDuration(key string, defaultValue time.Duration) time.Duration {
+	if value := os.Getenv(key); value != "" {
+		if d, err := time.ParseDuration(value); err == nil {
+			return d
+		}
 	}
 	return defaultValue
 }

--- a/main_test.go
+++ b/main_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"flag"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -333,7 +334,7 @@ func TestSmartMRManagement(t *testing.T) {
 
 func TestCreateHTTPClient(t *testing.T) {
 	// Test secure client
-	client := createHTTPClient(false)
+	client := createHTTPClient(&Config{})
 	if client == nil {
 		t.Fatal("Expected non-nil client")
 	}
@@ -342,12 +343,19 @@ func TestCreateHTTPClient(t *testing.T) {
 	}
 
 	// Test insecure client
-	insecureClient := createHTTPClient(true)
+	insecureClient := createHTTPClient(&Config{Insecure: true})
 	if insecureClient == nil {
 		t.Fatal("Expected non-nil insecure client")
 	}
 	if insecureClient.Timeout != 30*time.Second {
 		t.Errorf("Expected timeout 30s, got %v", insecureClient.Timeout)
+	}
+
+	// An explicit --timeout wins; a zero value keeps the 30s default, so a
+	// Config built without one behaves as it always did.
+	custom := createHTTPClient(&Config{Timeout: 5 * time.Second})
+	if custom.Timeout != 5*time.Second {
+		t.Errorf("Expected timeout 5s, got %v", custom.Timeout)
 	}
 }
 
@@ -2450,6 +2458,255 @@ func TestRunContextCancellation(t *testing.T) {
 	// was ignored.
 	if elapsed > 5*time.Second {
 		t.Errorf("run() took %v, expected it to abort as soon as the context was canceled", elapsed)
+	}
+}
+
+// TestIsRetryable pins the retry policy: idempotent verbs may repeat on
+// transient answers, POST may repeat only when the request never left.
+func TestIsRetryable(t *testing.T) {
+	dialErr := &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+	readErr := &net.OpError{Op: "read", Err: errors.New("connection reset by peer")}
+
+	tests := []struct {
+		name   string
+		method string
+		err    error
+		want   bool
+	}{
+		{"GET 500", http.MethodGet, &apiError{StatusCode: 500}, true},
+		{"GET 503", http.MethodGet, &apiError{StatusCode: 503}, true},
+		{"GET 429", http.MethodGet, &apiError{StatusCode: 429}, true},
+		{"GET 404", http.MethodGet, &apiError{StatusCode: 404}, false},
+		{"GET 400", http.MethodGet, &apiError{StatusCode: 400}, false},
+		{"PUT 502", http.MethodPut, &apiError{StatusCode: 502}, true},
+		{"POST 500 is not repeated", http.MethodPost, &apiError{StatusCode: 500}, false},
+		{"GET dial error", http.MethodGet, dialErr, true},
+		{"GET read error", http.MethodGet, readErr, true},
+		{"POST dial error", http.MethodPost, dialErr, true},
+		{"POST read error is not repeated", http.MethodPost, readErr, false},
+		{"unauthorized", http.MethodGet, errUnauthorized, false},
+		{"canceled", http.MethodGet, context.Canceled, false},
+		{"deadline exceeded", http.MethodGet, context.DeadlineExceeded, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRetryable(tt.method, tt.err); got != tt.want {
+				t.Errorf("isRetryable(%s, %v) = %v, want %v", tt.method, tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRetryDelay(t *testing.T) {
+	config := &Config{RetryDelay: time.Second}
+
+	tests := []struct {
+		name       string
+		config     *Config
+		attempt    int
+		retryAfter time.Duration
+		want       time.Duration
+	}{
+		{"first attempt", config, 0, 0, time.Second},
+		{"doubles", config, 1, 0, 2 * time.Second},
+		{"doubles again", config, 2, 0, 4 * time.Second},
+		{"capped", config, 20, 0, maxRetryDelay},
+		{"no overflow", config, 64, 0, maxRetryDelay},
+		{"zero delay falls back to the default", &Config{}, 0, 0, defaultRetryDelay},
+		{"Retry-After wins", config, 3, 7 * time.Second, 7 * time.Second},
+		{"Retry-After is capped too", config, 0, time.Hour, maxRetryDelay},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := retryDelay(tt.config, tt.attempt, tt.retryAfter); got != tt.want {
+				t.Errorf("retryDelay(attempt=%d, retryAfter=%s) = %s, want %s",
+					tt.attempt, tt.retryAfter, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	tests := []struct {
+		value string
+		want  time.Duration
+	}{
+		{"", 0},
+		{"5", 5 * time.Second},
+		{" 12 ", 12 * time.Second},
+		{"0", 0},
+		{"-1", 0},
+		{"Wed, 21 Oct 2015 07:28:00 GMT", 0},
+		{"nonsense", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			if got := parseRetryAfter(tt.value); got != tt.want {
+				t.Errorf("parseRetryAfter(%q) = %s, want %s", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDoRequestRetries covers issue #145 end-to-end against a server that fails
+// a fixed number of times before succeeding.
+func TestDoRequestRetries(t *testing.T) {
+	tests := []struct {
+		name         string
+		method       string
+		failures     int
+		failStatus   int
+		retries      int
+		wantAttempts int
+		wantErr      bool
+	}{
+		{"GET recovers from 503", http.MethodGet, 2, 503, 2, 3, false},
+		{"GET gives up after the last retry", http.MethodGet, 5, 503, 2, 3, true},
+		{"GET does not retry 404", http.MethodGet, 5, 404, 2, 1, true},
+		{"POST does not retry 503", http.MethodPost, 5, 503, 2, 1, true},
+		{"no retries configured", http.MethodGet, 1, 500, 0, 1, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var attempts int
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				attempts++
+				if attempts <= tt.failures {
+					w.WriteHeader(tt.failStatus)
+					return
+				}
+				if _, err := w.Write([]byte(`{"ok":true}`)); err != nil {
+					t.Errorf("write response: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			config := &Config{
+				PrivateToken: "test-token",
+				ProjectID:    123,
+				GitLabURL:    server.URL,
+				Retries:      tt.retries,
+				RetryDelay:   time.Millisecond,
+			}
+
+			var reqBody any
+			if tt.method == http.MethodPost {
+				reqBody = map[string]string{"title": "x"}
+			}
+
+			_, err := doRequest(context.Background(), server.Client(), config, tt.method, "projects/123", reqBody)
+
+			if tt.wantErr && err == nil {
+				t.Error("expected an error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if attempts != tt.wantAttempts {
+				t.Errorf("attempts = %d, want %d", attempts, tt.wantAttempts)
+			}
+		})
+	}
+}
+
+// TestDoRequestRespectsRetryAfter checks that a 429 carrying Retry-After waits
+// for the interval GitLab asked for rather than the configured backoff.
+func TestDoRequestRespectsRetryAfter(t *testing.T) {
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts++
+		if attempts == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		if _, err := w.Write([]byte(`{}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	config := &Config{
+		PrivateToken: "test-token",
+		ProjectID:    123,
+		GitLabURL:    server.URL,
+		Retries:      1,
+		RetryDelay:   time.Millisecond, // far shorter than the Retry-After
+	}
+
+	start := time.Now()
+	if _, err := doRequest(context.Background(), server.Client(), config,
+		http.MethodGet, "projects/123", nil); err != nil {
+		t.Fatalf("doRequest() error = %v", err)
+	}
+	elapsed := time.Since(start)
+
+	if attempts != 2 {
+		t.Errorf("attempts = %d, want 2", attempts)
+	}
+	if elapsed < time.Second {
+		t.Errorf("waited %s, expected at least the 1s from Retry-After", elapsed)
+	}
+}
+
+// TestDoRequestRetrySendsBodyAgain guards against the reader being consumed by
+// the first attempt: a retried PUT must send the same payload.
+func TestDoRequestRetrySendsBodyAgain(t *testing.T) {
+	var bodies []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		bodies = append(bodies, string(body))
+		if len(bodies) == 1 {
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		if _, werr := w.Write([]byte(`{}`)); werr != nil {
+			t.Errorf("write response: %v", werr)
+		}
+	}))
+	defer server.Close()
+
+	config := &Config{
+		PrivateToken: "test-token",
+		ProjectID:    123,
+		GitLabURL:    server.URL,
+		Retries:      1,
+		RetryDelay:   time.Millisecond,
+	}
+
+	if _, err := doRequest(context.Background(), server.Client(), config,
+		http.MethodPut, "projects/123/merge_requests/1", map[string]string{"title": "x"}); err != nil {
+		t.Fatalf("doRequest() error = %v", err)
+	}
+
+	if len(bodies) != 2 {
+		t.Fatalf("got %d attempts, want 2", len(bodies))
+	}
+	if bodies[0] != bodies[1] {
+		t.Errorf("retry sent %q, first attempt sent %q", bodies[1], bodies[0])
+	}
+}
+
+// TestSleepRespectsContext checks that a canceled context ends the backoff wait
+// immediately instead of blocking for the full delay.
+func TestSleepRespectsContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	err := sleep(ctx, time.Hour)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("sleep returned after %s, expected it to be immediate", elapsed)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -2485,16 +2485,72 @@ func TestIsRetryable(t *testing.T) {
 		{"POST dial error", http.MethodPost, dialErr, true},
 		{"POST read error is not repeated", http.MethodPost, readErr, false},
 		{"unauthorized", http.MethodGet, errUnauthorized, false},
-		{"canceled", http.MethodGet, context.Canceled, false},
-		{"deadline exceeded", http.MethodGet, context.DeadlineExceeded, false},
+		// A --timeout that elapsed surfaces as DeadlineExceeded while the caller's
+		// context is still live: that is a transient failure, so GET repeats it.
+		{"GET request timeout", http.MethodGet, context.DeadlineExceeded, true},
+		{"POST request timeout is not repeated", http.MethodPost, context.DeadlineExceeded, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isRetryable(tt.method, tt.err); got != tt.want {
+			if got := isRetryable(context.Background(), tt.method, tt.err); got != tt.want {
 				t.Errorf("isRetryable(%s, %v) = %v, want %v", tt.method, tt.err, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestIsRetryableStopsOnCancellation checks that a caller who gave up ends the
+// retries, however transient the underlying failure looks.
+func TestIsRetryableStopsOnCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if isRetryable(ctx, http.MethodGet, &apiError{StatusCode: 503}) {
+		t.Error("expected no retry once the caller's context is done")
+	}
+}
+
+// TestDoRequestRetriesRequestTimeout is the end-to-end form of the same rule:
+// a request that outran --timeout is retried, and the retry succeeds.
+func TestDoRequestRetriesRequestTimeout(t *testing.T) {
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts == 1 {
+			// Outlast the client timeout without hanging the test if it is not hit.
+			select {
+			case <-r.Context().Done():
+			case <-time.After(2 * time.Second):
+			}
+			return
+		}
+		if _, err := w.Write([]byte(`{"ok":true}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	config := &Config{
+		PrivateToken: "test-token",
+		ProjectID:    123,
+		GitLabURL:    server.URL,
+		Timeout:      100 * time.Millisecond,
+		Retries:      1,
+		RetryDelay:   time.Millisecond,
+	}
+
+	client := createHTTPClient(config)
+
+	body, err := doRequest(context.Background(), client, config, http.MethodGet, "projects/123", nil)
+	if err != nil {
+		t.Fatalf("doRequest() error = %v", err)
+	}
+	if string(body) != `{"ok":true}` {
+		t.Errorf("body = %q, want %q", string(body), `{"ok":true}`)
+	}
+	if attempts != 2 {
+		t.Errorf("attempts = %d, want 2", attempts)
 	}
 }
 


### PR DESCRIPTION
Closes #145, closes #77 (the two describe the same feature).

Replaces #163, which GitHub auto-closed when its base branch (`refactor/http-helper`, now merged as #161) was deleted. Same work, rebased onto `main`.

## Behaviour

Two retries by default, waiting 1s then 2s, capped at 30s. `--retries 0` turns it off. `--timeout` (default 30s) replaces the hardcoded client timeout, since with retries the total time budget becomes something worth controlling. All three read env vars too: `GITLAB_AUTO_MR_RETRIES`, `GITLAB_AUTO_MR_RETRY_DELAY`, `GITLAB_AUTO_MR_TIMEOUT`.

Default is 2 rather than #77's suggested 0: the motivation in #145 is that the tool *reads as flaky* when a restarting GitLab fails a job that a re-run would have fixed. Opt-in retries do not fix that for anyone who never reads the flag list.

## What may be retried

The issue's central warning — "retrying `POST /merge_requests` after a timeout could create a second MR" — is what the policy is built around. The question is not only *what failed* but *what a repeat could do*:

| Request | 5xx / 429 | network error |
| --- | --- | --- |
| `GET`, `PUT` | retried | retried |
| `POST` | not retried | only on a dial failure |

`GET` and `PUT` are idempotent, so at worst GitLab applies the same change twice. For `POST`, a dial failure is the one case where the request demonstrably never reached the server, so it is the one case that is safe to repeat.

4xx answers other than 429 are never retried — they are real answers. Neither is a 401, nor a context the caller has cancelled.

**One subtlety worth reviewing carefully.** "The caller gave up" is read from `ctx.Err()`, not from the error. `http.Client`'s own `Timeout` *also* surfaces as `context.DeadlineExceeded` — I verified this rather than assuming it — so matching on the error would have excluded the very case retries exist for: a hung request that a second attempt completes. `TestDoRequestRetriesRequestTimeout` pins that: a server that outlasts a 100 ms `--timeout` on the first attempt and answers on the second.

`Retry-After` wins over the computed backoff when GitLab sends it, capped at 30s. Only the delay-seconds form is parsed; the HTTP-date form is ignored rather than guessed at. Backoff waiting selects on `ctx.Done()`, so Ctrl-C during a retry wait exits immediately.

## Zero values still behave

Defaults are applied where they are used, not only in `parseFlags`, so a `Config` built directly — as every test does — keeps the old behaviour: no retries and a 30s timeout.

## Tests

`TestIsRetryable` (16 cases), `TestIsRetryableStopsOnCancellation`, `TestRetryDelay` (doubling, cap, shift overflow at attempt 64, `Retry-After` precedence), `TestParseRetryAfter`, `TestDoRequestRetries` (five end-to-end cases counting real server hits), `TestDoRequestRespectsRetryAfter`, `TestDoRequestRetrySendsBodyAgain` (guards against a consumed body reader), `TestDoRequestRetriesRequestTimeout`, `TestSleepRespectsContext`.

```
$ go test -race ./...
ok  	gitlab-auto-mr	3.606s
$ golangci-lint run
0 issues.
```