### PR TITLE
fix: count only merge request pipelines when skipping a duplicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Docker images are automatically built and published to GitHub Container Registry
 - `vX.Y` - Latest patch version of a minor release
 - `vX` - Latest minor and patch version of a major release (e.g., `v1`)
 
+The image runs as uid `10001`, not root. The tool itself only needs outbound
+HTTPS, but anything else in the same job that writes to the workspace must be
+able to do so as that user.
+
 ### Pull the Image
 
 ```bash
@@ -206,9 +210,17 @@ Skipping pipeline creation; pass --force-pipeline to create another.
 
 That is what keeps a retried job, a manual re-run, or a later run against the
 same MR from stacking up pipelines for one commit. Use `--force-pipeline` when
-re-running the checks is exactly the point. If the pipeline list cannot be read,
-the tool creates one anyway: a duplicate is a better outcome than checks that
-silently did not run.
+re-running the checks is exactly the point — including when the existing
+pipeline for that commit failed, since the check looks at the commit, not at the
+result.
+
+Only pipelines GitLab reports as merge request pipelines count. The branch
+pipeline running this job is attached to the same MR and the same commit, and
+treating it as a match would mean never creating the merge request pipeline at
+all. If the pipeline list cannot be read, the tool creates one anyway: a
+duplicate is a better outcome than checks that silently did not run. The same
+applies to projects using merged results pipelines, where the pipeline's commit
+is a simulated merge and never equals the branch head.
 
 Two things to expect:
 

--- a/main.go
+++ b/main.go
@@ -34,6 +34,10 @@ const (
 	wipPrefix   = "wip"
 )
 
+// pipelineSourceMergeRequest is the `source` GitLab reports for a merge request
+// pipeline, as opposed to the `push` of an ordinary branch pipeline.
+const pipelineSourceMergeRequest = "merge_request_event"
+
 // errShowVersion is a sentinel error returned by parseFlags when --version has
 // been handled (version printed to stdout). Callers should treat it as a clean
 // exit with status 0 rather than a real error.
@@ -87,6 +91,8 @@ type Pipeline struct {
 	Status string `json:"status"`
 	WebURL string `json:"web_url"`
 	SHA    string `json:"sha"`
+	Source string `json:"source"`
+	Ref    string `json:"ref"`
 }
 
 type Issue struct {
@@ -603,8 +609,15 @@ func triggerMRPipeline(ctx context.Context, client *http.Client, config *Config,
 	return nil
 }
 
-// findPipelineForSHA returns the MR's existing pipeline for its head commit, or
-// nil when there is none.
+// findPipelineForSHA returns the MR's existing merge request pipeline for its
+// head commit, or nil when there is none.
+//
+// The endpoint lists every pipeline attached to the MR, branch pipelines
+// included — the docs' own example shows a plain branch ref. Matching on the
+// commit alone would therefore match the branch pipeline that is usually
+// running this very job, and skipping on that would mean never creating the
+// merge request pipeline this tool exists to create. Only pipelines GitLab
+// reports as merge_request_event count.
 //
 // With an unknown head SHA there is nothing to compare against, so it reports
 // no match and the caller creates a pipeline: a duplicate is a better outcome
@@ -628,7 +641,7 @@ func findPipelineForSHA(
 	}
 
 	for i := range pipelines {
-		if pipelines[i].SHA == mr.SHA {
+		if pipelines[i].Source == pipelineSourceMergeRequest && pipelines[i].SHA == mr.SHA {
 			return &pipelines[i], nil
 		}
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1655,6 +1655,9 @@ func TestMergeLabels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := mergeLabels(tt.base, tt.extra)
+			if tt.expected == nil && got != nil {
+				t.Errorf("mergeLabels(%v, %v) = %#v, want nil", tt.base, tt.extra, got)
+			}
 			if len(got) != len(tt.expected) {
 				t.Fatalf("mergeLabels(%v, %v) = %v, want %v", tt.base, tt.extra, got, tt.expected)
 			}
@@ -1822,6 +1825,118 @@ func captureOutput(t *testing.T, fn func()) string {
 	return out
 }
 
+// TestRunLabelAndMilestoneOnUpdate is the update-path counterpart of
+// TestRunLabelAndMilestone. It matters more than the create path: this is where
+// a regression could overwrite labels a person set on the MR by hand, or clear
+// them outright by sending an empty list.
+func TestRunLabelAndMilestoneOnUpdate(t *testing.T) {
+	tests := []struct {
+		name             string
+		labels           []string
+		milestoneID      int
+		useIssueName     bool
+		expectedLabels   []string
+		expectedMileston int
+	}{
+		{
+			name:             "flags only",
+			labels:           []string{"bug"},
+			milestoneID:      5,
+			expectedLabels:   []string{"bug"},
+			expectedMileston: 5,
+		},
+		{
+			name:             "merged with issue data",
+			labels:           []string{"bug", "shared"},
+			useIssueName:     true,
+			expectedLabels:   []string{"bug", "shared", "from-issue"},
+			expectedMileston: 99,
+		},
+		{
+			name:             "neither leaves both out of the request",
+			expectedLabels:   nil,
+			expectedMileston: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var raw []byte
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case r.URL.Path == "/api/v4/projects/123" && r.Method == http.MethodGet:
+					if err := json.NewEncoder(w).Encode(Project{ID: 123, DefaultBranch: "main"}); err != nil {
+						t.Errorf("encode project: %v", err)
+					}
+				case r.URL.Path == "/api/v4/projects/123/merge_requests" && r.Method == http.MethodGet:
+					if _, err := w.Write([]byte(`[{"id":1,"iid":42,"title":"Old"}]`)); err != nil {
+						t.Errorf("write MR list: %v", err)
+					}
+				case r.URL.Path == "/api/v4/projects/123/issues/42" && r.Method == http.MethodGet:
+					if _, err := w.Write([]byte(
+						`{"id":1,"iid":42,"labels":["from-issue","shared"],"milestone":{"id":99}}`,
+					)); err != nil {
+						t.Errorf("write issue: %v", err)
+					}
+				case r.URL.Path == "/api/v4/projects/123/merge_requests/42" && r.Method == http.MethodPut:
+					body, err := io.ReadAll(r.Body)
+					if err != nil {
+						t.Errorf("read update body: %v", err)
+					}
+					raw = body
+					if _, err := w.Write([]byte(`{"id":1,"iid":42}`)); err != nil {
+						t.Errorf("write update response: %v", err)
+					}
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			config := &Config{
+				PrivateToken: "test-token",
+				SourceBranch: "feature/#42-test",
+				ProjectID:    123,
+				GitLabURL:    server.URL,
+				UserIDs:      []int{1},
+				TargetBranch: "main",
+				UpdateMR:     true,
+				Labels:       tt.labels,
+				MilestoneID:  tt.milestoneID,
+				UseIssueName: tt.useIssueName,
+			}
+
+			if err := run(context.Background(), config); err != nil {
+				t.Fatalf("run() error = %v", err)
+			}
+
+			var sent MRUpdateRequest
+			if err := json.Unmarshal(raw, &sent); err != nil {
+				t.Fatalf("decode update request: %v", err)
+			}
+
+			if sent.MilestoneID != tt.expectedMileston {
+				t.Errorf("MilestoneID = %d, want %d", sent.MilestoneID, tt.expectedMileston)
+			}
+			if len(sent.Labels) != len(tt.expectedLabels) {
+				t.Fatalf("Labels = %v, want %v", sent.Labels, tt.expectedLabels)
+			}
+			for i := range sent.Labels {
+				if sent.Labels[i] != tt.expectedLabels[i] {
+					t.Errorf("Labels[%d] = %q, want %q", i, sent.Labels[i], tt.expectedLabels[i])
+				}
+			}
+
+			// An empty list would CLEAR the MR's labels, which is not the same
+			// as leaving them alone; assert on the wire, not on the struct.
+			if tt.expectedLabels == nil && strings.Contains(string(raw), `"labels"`) {
+				t.Errorf("update request carries a labels field: %s", raw)
+			}
+		})
+	}
+}
+
 // TestPrintMRURL covers issue #75: the MR's browser URL is printed after every
 // operation that identifies an MR, and nothing is printed when GitLab did not
 // return one.
@@ -1927,6 +2042,15 @@ func TestPrintMRURL(t *testing.T) {
 // pipeline was created. existingSHA, when non-empty, is the SHA of a pipeline
 // GitLab already has for the MR.
 func pipelineServer(t *testing.T, existingSHA string, listStatus int) (*httptest.Server, *int) {
+	return pipelineServerWithSource(t, existingSHA, pipelineSourceMergeRequest, listStatus)
+}
+
+// pipelineServerWithSource is pipelineServer with control over the `source` of
+// the pipeline the list endpoint reports, which is what separates a merge
+// request pipeline from the branch pipeline running the job.
+func pipelineServerWithSource(
+	t *testing.T, existingSHA, source string, listStatus int,
+) (*httptest.Server, *int) {
 	t.Helper()
 
 	created := 0
@@ -1947,6 +2071,7 @@ func pipelineServer(t *testing.T, existingSHA string, listStatus int) (*httptest
 			body := "[]"
 			if existingSHA != "" {
 				body = `[{"id":7,"status":"running","sha":"` + existingSHA +
+					`","source":"` + source +
 					`","web_url":"https://gitlab.example.com/p/-/pipelines/7"}]`
 			}
 			if _, err := w.Write([]byte(body)); err != nil {
@@ -2042,9 +2167,53 @@ func TestTriggerMRPipelineDeduplicates(t *testing.T) {
 	}
 }
 
-// TestRunTriggersPipelineOnUpdate covers issue #150: updating an existing MR
-// triggers a pipeline too, since the branch has moved. The MR carries a SHA
-// that has no pipeline yet, which is the case where a new one is wanted.
+// TestTriggerMRPipelineIgnoresBranchPipelines is the regression test for the
+// endpoint's actual semantics: GET .../merge_requests/:iid/pipelines lists every
+// pipeline attached to the MR, branch pipelines included. The branch pipeline
+// for the head commit is normally the one running this very job, so matching on
+// the commit alone would skip creating the merge request pipeline every time —
+// exactly the failure --trigger-pipeline exists to prevent.
+func TestTriggerMRPipelineIgnoresBranchPipelines(t *testing.T) {
+	const headSHA = "abc123def456"
+
+	tests := []struct {
+		name        string
+		source      string
+		wantCreated int
+	}{
+		{"branch pipeline for the same commit does not count", "push", 1},
+		{"scheduled pipeline for the same commit does not count", "schedule", 1},
+		{"merge request pipeline for the same commit counts", pipelineSourceMergeRequest, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, created := pipelineServerWithSource(t, headSHA, tt.source, 0)
+			defer server.Close()
+
+			config := &Config{
+				PrivateToken:    "test-token",
+				ProjectID:       123,
+				GitLabURL:       server.URL,
+				TriggerPipeline: true,
+			}
+
+			err := triggerMRPipeline(context.Background(), server.Client(), config,
+				&MergeRequest{IID: 42, SHA: headSHA})
+			if err != nil {
+				t.Fatalf("triggerMRPipeline() error = %v", err)
+			}
+			if *created != tt.wantCreated {
+				t.Errorf("pipelines created = %d, want %d", *created, tt.wantCreated)
+			}
+		})
+	}
+}
+
+// TestRunTriggersPipelineOnUpdate pins the decision taken for issue #150:
+// updating an existing MR triggers a pipeline too, since the branch has moved.
+// The MR's head commit has no merge request pipeline of its own — only one for
+// an earlier commit — so the per-commit check must not stand in the way.
 func TestRunTriggersPipelineOnUpdate(t *testing.T) {
 	created := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2063,7 +2232,9 @@ func TestRunTriggersPipelineOnUpdate(t *testing.T) {
 				t.Errorf("write update response: %v", err)
 			}
 		case r.URL.Path == "/api/v4/projects/123/merge_requests/42/pipelines" && r.Method == http.MethodGet:
-			if _, err := w.Write([]byte(`[{"id":7,"status":"success","sha":"oldsha"}]`)); err != nil {
+			if _, err := w.Write([]byte(
+				`[{"id":7,"status":"success","sha":"oldsha","source":"merge_request_event"}]`,
+			)); err != nil {
 				t.Errorf("write pipeline list: %v", err)
 			}
 		case r.URL.Path == "/api/v4/projects/123/merge_requests/42/pipelines" && r.Method == http.MethodPost:


### PR DESCRIPTION
Follow-up to #165, which I merged with a bug in it. Found on a second review pass; the fix is small, the consequence was not.

## What was wrong

`GET /projects/:id/merge_requests/:iid/pipelines` lists **every** pipeline attached to the merge request — branch pipelines included. GitLab's own example response for that endpoint shows a plain branch `ref`, which a detached merge request pipeline can never have. `findPipelineForSHA` compared only `sha`, and `Pipeline` did not even decode `source`.

So, in the exact setup `--trigger-pipeline` was written for:

1. You push `feature/x` at commit `abc…`; GitLab starts a **branch** pipeline for `abc…` — the pipeline running this very job.
2. The tool creates the MR; the create response carries `sha: abc…`.
3. The dedup check lists the MR's pipelines, finds that branch pipeline, and matches on the commit.
4. Output: `Merge request pipeline already exists for commit abc12345 … Skipping pipeline creation.`

**No merge request pipeline is ever created.** Jobs gated on `merge_request_event` never run, and the log claims a pipeline exists when the one it found is the branch pipeline. That is verbatim the failure the function's own doc comment says it prevents, and it contradicts the README, which promises two pipelines on the push that creates the MR.

## The fix

`Pipeline` decodes `source` (and `ref`), and only `source == "merge_request_event"` counts as a match.

Projects on **merged results pipelines** are covered by the same change in the other direction: there the MR pipeline's `sha` is a simulated merge commit and never equals the branch head, so nothing matches and a pipeline is created. Fail-open — the README now says so rather than promising a guarantee that does not hold there.

## Why the existing tests missed it

`pipelineServer` fabricated list entries with only `id/status/sha/web_url` — no field distinguished a branch pipeline from a merge request one, so the fixture could not express the failing case. It now takes a `source`, and `TestTriggerMRPipelineIgnoresBranchPipelines` serves `push`- and `schedule`-sourced pipelines for the head commit and asserts a pipeline is still created. Verified it fails against the old logic:

```
--- FAIL: TestTriggerMRPipelineIgnoresBranchPipelines/branch_pipeline_for_the_same_commit_does_not_count
    main_test.go:2092: pipelines created = 0, want 1
```

## Also in here

Two smaller review findings, both about tests rather than behaviour:

- **`TestRunLabelAndMilestoneOnUpdate`** — `TestRunLabelAndMilestone` only ever captured the *create* request, leaving the update path untested. That is the riskier one: it is where a regression could overwrite labels a person set on the MR by hand, or clear them by sending `"labels": []`. The new test asserts on the raw `PUT` body, including that no `labels` field is sent when there is nothing to set.
- **`TestMergeLabels`** now asserts the nil-ness its subtest name claims; the old length-and-elements comparison would have passed for a non-nil empty slice.

Plus two README notes: that `--force-pipeline` is also the answer when the existing pipeline for a commit *failed* (the check looks at the commit, not the result), and that the image runs as uid 10001 after #154 — relevant to anything else in the job that writes to the workspace.

```
$ go test -race ./...
ok  	gitlab-auto-mr	1.898s
$ golangci-lint run
0 issues.
```

Sources: [Merge requests API](https://docs.gitlab.com/api/merge_requests/), [Merge request pipelines](https://docs.gitlab.com/ci/pipelines/merge_request_pipelines/), [Merged results pipelines](https://docs.gitlab.com/ci/pipelines/merged_results_pipelines/)
