### PR TITLE
fix(ci): restore the #nosec annotation dropped in the request-helper refactor

### DIFF
--- a/main.go
+++ b/main.go
@@ -997,6 +997,8 @@ func getDescriptionData(descriptionPath string) string {
 		return ""
 	}
 
+	// #nosec G304 -- the path comes from the caller's own --description flag and the
+	// tool runs with the caller's rights, so there is no privilege boundary to cross.
 	data, err := os.ReadFile(descriptionPath)
 	if err != nil {
 		fmt.Printf("Unable to read description file at %s: %v. No description will be set.\n",


### PR DESCRIPTION
`main` is currently failing the **Security Scan** job on every pull request. My fault, in two steps:

- #155 annotated the two known-safe gosec findings (`G402` for `--insecure`, `G304` for `--description`) and removed `continue-on-error`, making the scanner blocking.
- #161 rewrote the block of API functions that `getDescriptionData` sits in, and did not carry its `// #nosec G304` comment across.

So gosec re-reports a finding that had already been reviewed and accepted, and the job fails.

```
$ gosec ./...          # before
  Issues : 1
$ gosec ./...          # after
  Nosec  : 2
  Issues : 0
```

What let it through is exactly the asymmetry #155 pointed out: **`golangci-lint`'s gosec honours `//nolint`, the standalone binary only honours `#nosec`.** `golangci-lint run` reports `0 issues` in both cases, so a local check does not catch it. Worth knowing when touching those two lines.

I also merged #166 and #167 while this job was red — I was checking the PR status with a script that mis-parsed the two-word job name and dropped its column, so I read a failing job as passing. Both PRs are otherwise green and their own content is unaffected by this; this restores the job to passing on `main`.