### PR TITLE
feat: add --ca-cert for a self-hosted GitLab behind a private CA

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ create_only:
   `--target-branch`/`-t`; when neither is set, the project's default branch is used.
 - `GITLAB_AUTO_MR_LABELS` - Labels for the MR (comma-separated). Overridden by `--label`.
 - `GITLAB_AUTO_MR_MILESTONE` - Milestone ID for the MR. Overridden by `--milestone`.
+- `GITLAB_AUTO_MR_CA_CERT` - Path to a PEM CA certificate to trust in addition to the system pool
 - `GITLAB_AUTO_MR_TIMEOUT` - Timeout for a single API request (default `30s`)
 - `GITLAB_AUTO_MR_RETRIES` - Retries for transient failures (default `2`)
 - `GITLAB_AUTO_MR_RETRY_DELAY` - Delay before the first retry (default `1s`)
@@ -185,6 +186,7 @@ create_only:
 | `--timeout`             |       | Timeout for a single API request               | `30s`                  |
 | `--retries`             |       | Retries for transient failures (5xx, 429, network) | `2`                |
 | `--retry-delay`         |       | Delay before the first retry, doubled each time | `1s`                  |
+| `--ca-cert`             |       | PEM CA certificate to trust (`GITLAB_AUTO_MR_CA_CERT`) | -               |
 | `--insecure`            | `-k`  | Skip SSL certificate verification              | `false`                |
 
 ### Merge Request Pipelines
@@ -240,6 +242,20 @@ Two things to expect:
   role on the project. A `CI_JOB_TOKEN` cannot be used: the Merge Requests API
   is read-only for job tokens, so it can neither create the MR nor request a
   pipeline for it.
+
+## Self-hosted GitLab with a private CA
+
+If your instance presents a certificate from an internal CA, point the tool at
+that CA rather than turning verification off:
+
+```bash
+gitlab-auto-mr --ca-cert /etc/ssl/certs/internal-ca.pem
+```
+
+The certificate is added to the system trust store rather than replacing it, so
+other hosts keep working. `--insecure`/`-k` remains available for throwaway
+cases, but the two are mutually exclusive: disabling verification would make the
+CA pointless, and this tool carries an `api`-scoped token.
 
 ## Retries
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -80,6 +81,7 @@ type Config struct {
 	Timeout            time.Duration
 	Retries            int
 	RetryDelay         time.Duration
+	CACert             string
 }
 
 type Project struct {
@@ -187,6 +189,8 @@ func parseFlags() (*Config, error) {
 	flag.StringVar(&reviewerIDsStr, "reviewer-id", "", "Reviewer IDs (comma-separated)")
 	flag.BoolVar(&config.Insecure, "insecure", false, "Skip SSL verification")
 	flag.BoolVar(&config.Insecure, "k", false, "Skip SSL verification (short)")
+	flag.StringVar(&config.CACert, "ca-cert", getEnv("GITLAB_AUTO_MR_CA_CERT", ""),
+		"Path to a PEM CA certificate to trust in addition to the system pool")
 	// Both spellings share one variable, so they must share one default: whichever
 	// flag.StringVar runs last decides the initial value.
 	targetBranchDefault := getEnv("GITLAB_AUTO_MR_TARGET_BRANCH", "")
@@ -290,6 +294,13 @@ func isDraftPrefix(prefix string) bool {
 }
 
 func validateConfig(config *Config) error {
+	if config.CACert != "" && config.Insecure {
+		return fmt.Errorf(
+			"--ca-cert cannot be used with --insecure: " +
+				"--insecure disables verification entirely, which would make the CA pointless",
+		)
+	}
+
 	if config.ForcePipeline && !config.TriggerPipeline {
 		return fmt.Errorf("--force-pipeline has no effect without --trigger-pipeline")
 	}
@@ -327,7 +338,10 @@ func run(ctx context.Context, config *Config) error {
 		return err
 	}
 
-	client := createHTTPClient(config)
+	client, err := createHTTPClient(config)
+	if err != nil {
+		return err
+	}
 
 	project, err := getProject(ctx, client, config)
 	if err != nil {
@@ -696,7 +710,7 @@ func urlSuffix(webURL string) string {
 	return ": " + webURL
 }
 
-func createHTTPClient(config *Config) *http.Client {
+func createHTTPClient(config *Config) (*http.Client, error) {
 	timeout := config.Timeout
 	if timeout <= 0 {
 		timeout = defaultTimeout
@@ -706,16 +720,50 @@ func createHTTPClient(config *Config) *http.Client {
 		Timeout: timeout,
 	}
 
-	if config.Insecure {
+	switch {
+	case config.Insecure:
 		// #nosec G402 -- certificate verification is disabled only at the user's
 		// explicit request, via --insecure/-k.
-		tr := &http.Transport{
+		client.Transport = &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}
-		client.Transport = tr
+
+	case config.CACert != "":
+		pool, err := caCertPool(config.CACert)
+		if err != nil {
+			return nil, err
+		}
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12},
+		}
 	}
 
-	return client
+	return client, nil
+}
+
+// caCertPool returns the system trust store with the given PEM certificate
+// added. It is additive on purpose: a self-hosted GitLab behind an internal CA
+// is usually reached alongside other hosts with public certificates.
+func caCertPool(path string) (*x509.CertPool, error) {
+	// #nosec G304 -- the path comes from the caller's own --ca-cert flag and the
+	// tool runs with the caller's rights, so there is no privilege boundary here.
+	pem, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read CA certificate %s: %w", path, err)
+	}
+
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		// Windows returns an error here rather than a pool; starting from an
+		// empty one still lets the given CA work.
+		pool = x509.NewCertPool()
+	}
+
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, fmt.Errorf("no PEM certificate found in %s", path)
+	}
+
+	return pool, nil
 }
 
 // apiError is returned by doRequest when GitLab answered with a status the

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"flag"
 	"io"
@@ -11,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -334,7 +336,10 @@ func TestSmartMRManagement(t *testing.T) {
 
 func TestCreateHTTPClient(t *testing.T) {
 	// Test secure client
-	client := createHTTPClient(&Config{})
+	client, err := createHTTPClient(&Config{})
+	if err != nil {
+		t.Fatalf("createHTTPClient() error = %v", err)
+	}
 	if client == nil {
 		t.Fatal("Expected non-nil client")
 	}
@@ -343,7 +348,10 @@ func TestCreateHTTPClient(t *testing.T) {
 	}
 
 	// Test insecure client
-	insecureClient := createHTTPClient(&Config{Insecure: true})
+	insecureClient, err := createHTTPClient(&Config{Insecure: true})
+	if err != nil {
+		t.Fatalf("createHTTPClient() error = %v", err)
+	}
 	if insecureClient == nil {
 		t.Fatal("Expected non-nil insecure client")
 	}
@@ -353,7 +361,10 @@ func TestCreateHTTPClient(t *testing.T) {
 
 	// An explicit --timeout wins; a zero value keeps the 30s default, so a
 	// Config built without one behaves as it always did.
-	custom := createHTTPClient(&Config{Timeout: 5 * time.Second})
+	custom, err := createHTTPClient(&Config{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("createHTTPClient() error = %v", err)
+	}
 	if custom.Timeout != 5*time.Second {
 		t.Errorf("Expected timeout 5s, got %v", custom.Timeout)
 	}
@@ -2540,7 +2551,10 @@ func TestDoRequestRetriesRequestTimeout(t *testing.T) {
 		RetryDelay:   time.Millisecond,
 	}
 
-	client := createHTTPClient(config)
+	client, err := createHTTPClient(config)
+	if err != nil {
+		t.Fatalf("createHTTPClient() error = %v", err)
+	}
 
 	body, err := doRequest(context.Background(), client, config, http.MethodGet, "projects/123", nil)
 	if err != nil {
@@ -2763,6 +2777,106 @@ func TestSleepRespectsContext(t *testing.T) {
 	}
 	if elapsed := time.Since(start); elapsed > time.Second {
 		t.Errorf("sleep returned after %s, expected it to be immediate", elapsed)
+	}
+}
+
+// writeServerCertPEM writes the certificate an httptest TLS server presents to
+// a temporary PEM file and returns its path.
+func writeServerCertPEM(t *testing.T, server *httptest.Server) string {
+	t.Helper()
+
+	cert := server.Certificate()
+	if cert == nil {
+		t.Fatal("server has no certificate")
+	}
+
+	path := filepath.Join(t.TempDir(), "ca.pem")
+	data := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+
+	return path
+}
+
+// TestCACert covers issue #146: a certificate given with --ca-cert is trusted
+// in addition to the system pool, so a self-hosted GitLab behind a private CA
+// can be reached without disabling verification.
+func TestCACert(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := w.Write([]byte(`{"id":123,"default_branch":"main"}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	certPath := writeServerCertPEM(t, server)
+
+	t.Run("trusted with --ca-cert", func(t *testing.T) {
+		config := &Config{PrivateToken: "tok", ProjectID: 123, GitLabURL: server.URL, CACert: certPath}
+
+		client, err := createHTTPClient(config)
+		if err != nil {
+			t.Fatalf("createHTTPClient() error = %v", err)
+		}
+
+		project, err := getProject(context.Background(), client, config)
+		if err != nil {
+			t.Fatalf("getProject() error = %v", err)
+		}
+		if project.ID != 123 {
+			t.Errorf("project.ID = %d, want 123", project.ID)
+		}
+	})
+
+	t.Run("rejected without it", func(t *testing.T) {
+		config := &Config{PrivateToken: "tok", ProjectID: 123, GitLabURL: server.URL}
+
+		client, err := createHTTPClient(config)
+		if err != nil {
+			t.Fatalf("createHTTPClient() error = %v", err)
+		}
+
+		if _, err := getProject(context.Background(), client, config); err == nil {
+			t.Error("expected a certificate verification error, got nil")
+		}
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		_, err := createHTTPClient(&Config{CACert: filepath.Join(t.TempDir(), "absent.pem")})
+		if err == nil {
+			t.Fatal("expected an error for a missing CA file")
+		}
+		if !strings.Contains(err.Error(), "unable to read CA certificate") {
+			t.Errorf("error = %v, want it to mention the unreadable file", err)
+		}
+	})
+
+	t.Run("file without a certificate", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "junk.pem")
+		if err := os.WriteFile(path, []byte("not a certificate"), 0o600); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+
+		_, err := createHTTPClient(&Config{CACert: path})
+		if err == nil {
+			t.Fatal("expected an error for a file with no PEM certificate")
+		}
+		if !strings.Contains(err.Error(), "no PEM certificate found") {
+			t.Errorf("error = %v, want it to mention the missing certificate", err)
+		}
+	})
+}
+
+// TestCACertWithInsecureRejected checks the two flags are refused together
+// rather than one silently winning.
+func TestCACertWithInsecureRejected(t *testing.T) {
+	err := validateConfig(&Config{CACert: "/tmp/ca.pem", Insecure: true})
+	if err == nil {
+		t.Fatal("expected an error for --ca-cert with --insecure")
+	}
+	if !strings.Contains(err.Error(), "--ca-cert cannot be used with --insecure") {
+		t.Errorf("error = %v", err)
 	}
 }
 


### PR DESCRIPTION
Closes #146.

Replaces #164, which GitHub auto-closed when its base branch (`feat/retry-timeout`, now merged as #166) was deleted. Same work, rebased onto `main`.

## Behaviour

```bash
gitlab-auto-mr --ca-cert /etc/ssl/certs/internal-ca.pem
```

Also `GITLAB_AUTO_MR_CA_CERT`. The certificate is **appended to a copy of the system pool**, not substituted for it — a self-hosted GitLab behind an internal CA is normally reached from a runner that also talks to hosts with public certificates. On Windows, where `x509.SystemCertPool()` returns an error rather than a pool, it falls back to an empty pool so the given CA still works.

## `--insecure` and `--ca-cert` are refused together

The issue said keeping `--insecure` is fine, and it is kept. But accepting both and letting one silently win is the worst outcome: the user thinks they configured a CA while verification is off. `validateConfig` rejects the pair with a message that says why.

## Consequences worth noting

`createHTTPClient` can now fail — reading and parsing the PEM happens there — so it returns `(*http.Client, error)` and `run()` reports it like any other error. Errors name the file: `unable to read CA certificate /path: …` and `no PEM certificate found in /path`, so a mistyped path or a DER file is not mistaken for a TLS handshake failure.

The new `os.ReadFile` carries a `#nosec G304` with its reason, not a `//nolint` — the standalone gosec that #155 made blocking honours only the former. (The first push of this branch failed Security Scan for exactly that.)

## Tests

`TestCACert` runs against a real `httptest.NewTLSServer`, writing the certificate it presents to a temp PEM:

- **trusted with `--ca-cert`** — `getProject` succeeds over TLS against that server;
- **rejected without it** — the same call fails, which is what makes the first case meaningful;
- **missing file** and **file without a certificate** — each produces its own error.

`TestCACertWithInsecureRejected` covers the mutual exclusion.

```
$ go test -race ./...
ok  	gitlab-auto-mr	3.916s
$ golangci-lint run
0 issues.
$ gosec ./...
  Nosec  : 3
  Issues : 0
```