### PR TITLE
docs: restore the Operating section lost in a rebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,28 @@ Two things to expect:
   is read-only for job tokens, so it can neither create the MR nor request a
   pipeline for it.
 
+## Operating
+
+The tool acts on behalf of whoever owns `GITLAB_PRIVATE_TOKEN`. That dependency is
+easy to lose track of: merge requests start appearing "by themselves", and months
+later nobody remembers that behind them stands a live account holding an
+`api`-scoped token.
+
+- **Use a service account, not a person.** A personal token disappears when that
+  person leaves the company or rotates their credentials, and every MR the tool
+  opens is attributed to them.
+- **Give the account Developer on the project — no more.** That is enough to read
+  the project and to create, update and merge merge requests.
+- **`CI_JOB_TOKEN` cannot be substituted.** The Merge Requests API is read-only for
+  job tokens, so a personal or project access token with the `api` scope is
+  required.
+- **Plan for rotation.** GitLab no longer issues non-expiring personal access
+  tokens, so expiry is scheduled work. When the token expires, MR creation simply
+  stops — and "no new MRs" is a symptom that is easy to miss for weeks.
+- **Name the account so its purpose is obvious** (for example
+  `svc-gitlab-auto-mr`). Whoever finds it during a directory cleanup will decide
+  its fate based on the name alone; an account called `test1` gets deleted.
+
 ## Self-hosted GitLab with a private CA
 
 If your instance presents a certificate from an internal CA, point the tool at
@@ -409,6 +431,8 @@ Error: unable to get project 12345: unauthorized access, check your access token
 ```
 
 - Check your `GITLAB_PRIVATE_TOKEN` is valid and has `api` scope
+- An expired or revoked token gives the same message — see [Operating](#operating)
+  for who the token should belong to and why rotation is scheduled work
 
 **MR Already Exists**
 


### PR DESCRIPTION
The `Operating` section added in #152 — who `GITLAB_PRIVATE_TOKEN` should belong to, why `CI_JOB_TOKEN` cannot be substituted, and that rotation is scheduled work — is not on `main`.

My fault: while rebasing #157 I hit a `README.md` conflict, resolved it by taking one side of the file wholesale, then hand-restored only the lines I happened to be looking for (`GITLAB_AUTO_MR_TARGET_BRANCH`). The whole section went with the other side and I did not notice.

```
$ for c in 9acb9a9 3ff0522 …; do git show $c:README.md | grep -c 'service account, not a person'; done
9acb9a9  docs: document token ownership …      1
3ff0522  feat: add --label and --milestone …   0     <- lost here
```

This restores the section verbatim plus the Troubleshooting cross-reference that pointed at it, placed before the other operational sections (`Operating` → private CA → Retries → Building).

I checked the rest of the diff between that commit's README and today's: everything else that disappeared was a deliberate replacement (the `--target-branch` table row, the `--trigger-pipeline` wording, the 401 error text). This section was the only real loss.

Re-closes #149.