### PR TITLE
feat: add --draft and --ready flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ create_only:
 | `--squash-commits`      | `-s`  | Squash commits on merge                        | `false`                |
 | `--label`               |       | Labels for the MR, comma-separated (`GITLAB_AUTO_MR_LABELS`) | -         |
 | `--milestone`           |       | Milestone ID for the MR (`GITLAB_AUTO_MR_MILESTONE`) | -                  |
+| `--draft`               |       | Mark the MR as a draft                         | `false`                |
+| `--ready`               |       | Mark the MR ready by removing a draft prefix   | `false`                |
 | `--use-issue-name`      | `-i`  | Use issue data from branch name                | `false`                |
 | `--allow-collaboration` | `-a`  | Allow commits from merge target members        | `false`                |
 | `--reviewer-id`         |       | Reviewer user ID(s) (comma-separated)          | -                      |
@@ -264,6 +266,37 @@ later nobody remembers that behind them stands a live account holding an
 - **Name the account so its purpose is obvious** (for example
   `svc-gitlab-auto-mr`). Whoever finds it during a directory cleanup will decide
   its fate based on the name alone; an account called `test1` gets deleted.
+## Draft and Ready
+
+```bash
+gitlab-auto-mr --draft               # open (or keep) the MR as a draft
+gitlab-auto-mr --ready --update-mr   # take an existing MR out of draft
+```
+
+GitLab has **no writable draft field**: the `draft` flag in API responses is
+derived from the title, and the Merge Requests API accepts no `draft` parameter.
+Draft state is set by the title prefix — `Draft:`, `[Draft]` or `(Draft)` — which
+is what these two flags manage, so the caller does not have to know the
+convention.
+
+- `--draft` puts `Draft: ` at the front of the title, without doubling one that
+  is already there. A non-draft `--commit-prefix` is kept after the marker, so
+  `--draft --commit-prefix Feature` gives `Draft: Feature: my-branch`.
+- `--ready` removes a leading `Draft:`/`WIP:` marker in any of GitLab's accepted
+  spellings, and overrides the `Draft` default of `--commit-prefix` so the marker
+  is not simply added back.
+- On an existing MR, `--ready` strips the marker from the MR's **own** title
+  rather than rebuilding the title from the branch name — marking a draft ready
+  should not also rename a title someone wrote by hand. Pass `--title` to rename
+  deliberately.
+
+`--draft` and `--ready` are refused together, and `--draft` is refused with
+`--auto-merge` for the same reason a `Draft` commit prefix already was: GitLab
+does not auto-merge drafts. `--ready` is what makes the default prefix compatible
+with `--auto-merge`.
+
+`--commit-prefix` keeps working as before and is not deprecated; these flags are
+for when you want the state rather than a particular title.
 
 ## Self-hosted GitLab with a private CA
 

--- a/main.go
+++ b/main.go
@@ -82,6 +82,8 @@ type Config struct {
 	Retries            int
 	RetryDelay         time.Duration
 	CACert             string
+	Draft              bool
+	Ready              bool
 }
 
 type Project struct {
@@ -209,6 +211,8 @@ func parseFlags() (*Config, error) {
 		"Labels to set on the MR (comma-separated)")
 	flag.IntVar(&config.MilestoneID, "milestone", getEnvInt("GITLAB_AUTO_MR_MILESTONE", 0),
 		"Milestone ID to set on the MR")
+	flag.BoolVar(&config.Draft, "draft", false, "Mark the MR as a draft (GitLab reads the Draft: title prefix)")
+	flag.BoolVar(&config.Ready, "ready", false, "Mark the MR as ready by removing a Draft:/WIP: title prefix")
 	flag.BoolVar(&config.UseIssueName, "use-issue-name", false, "Use issue data from branch name")
 	flag.BoolVar(&config.UseIssueName, "i", false, "Use issue data from branch name (short)")
 	flag.BoolVar(&config.AllowCollaboration, "allow-collaboration", false, "Allow collaboration")
@@ -305,11 +309,20 @@ func validateConfig(config *Config) error {
 		return fmt.Errorf("--force-pipeline has no effect without --trigger-pipeline")
 	}
 
+	if config.Draft && config.Ready {
+		return fmt.Errorf("--draft cannot be used with --ready: they ask for opposite states")
+	}
+
+	if config.AutoMerge && config.Draft {
+		return fmt.Errorf("--auto-merge cannot be used with --draft: " +
+			"GitLab does not allow auto-merge for draft merge requests")
+	}
+
 	if config.AutoMerge && config.MRExists {
 		return fmt.Errorf("--auto-merge cannot be used with --mr-exists (dry run mode)")
 	}
 
-	if config.AutoMerge && isDraftPrefix(config.CommitPrefix) {
+	if config.AutoMerge && !config.Ready && isDraftPrefix(config.CommitPrefix) {
 		return fmt.Errorf(
 			"--auto-merge cannot be used with --commit-prefix %q: "+
 				"GitLab does not allow auto-merge for draft merge requests",
@@ -370,7 +383,7 @@ func run(ctx context.Context, config *Config) error {
 		return err
 	}
 
-	title := getMRTitle(config.CommitPrefix, config.Title, config.SourceBranch)
+	title := mrTitle(config, existingMR)
 	description := getDescriptionData(config.Description)
 
 	mr, err := handleMR(ctx, client, config, existingMR, title, description)
@@ -1024,6 +1037,58 @@ func getExistingMR(ctx context.Context, client *http.Client, config *Config) (*M
 	}
 
 	return nil, nil
+}
+
+// draftMarkers are the title prefixes GitLab accepts as marking a merge request
+// a draft. There is no writable draft field on the API — the flag GitLab returns
+// is derived from the title — so this is the only way to set the state.
+var draftMarkers = []string{
+	"draft:", "[draft]", "(draft)",
+	"wip:", "[wip]", "(wip)",
+}
+
+// stripDraftMarker removes a leading draft marker from a title, along with the
+// whitespace that follows it. Titles carrying no marker are returned unchanged.
+func stripDraftMarker(title string) string {
+	trimmed := strings.TrimSpace(title)
+	lower := strings.ToLower(trimmed)
+
+	for _, marker := range draftMarkers {
+		if strings.HasPrefix(lower, marker) {
+			return strings.TrimSpace(trimmed[len(marker):])
+		}
+	}
+
+	return trimmed
+}
+
+// mrTitle builds the title for this run, applying --draft and --ready.
+//
+// With --ready on an existing MR and no --title, the MR's own title is the base:
+// marking a draft ready should not also rename a title someone wrote by hand.
+// Otherwise the title is built as usual, except that a --commit-prefix which is
+// itself a draft marker is dropped — --draft supplies the marker itself, and
+// --ready must not have one added back by the flag's "Draft" default.
+func mrTitle(config *Config, existingMR *MergeRequest) string {
+	if config.Ready && config.Title == "" && existingMR != nil && existingMR.Title != "" {
+		return stripDraftMarker(existingMR.Title)
+	}
+
+	prefix := config.CommitPrefix
+	if (config.Draft || config.Ready) && isDraftPrefix(prefix) {
+		prefix = ""
+	}
+
+	title := getMRTitle(prefix, config.Title, config.SourceBranch)
+
+	switch {
+	case config.Ready:
+		return stripDraftMarker(title)
+	case config.Draft:
+		return "Draft: " + stripDraftMarker(title)
+	}
+
+	return title
 }
 
 func getMRTitle(prefix, title, sourceBranch string) string {

--- a/main_test.go
+++ b/main_test.go
@@ -2880,6 +2880,207 @@ func TestCACertWithInsecureRejected(t *testing.T) {
 	}
 }
 
+func TestStripDraftMarker(t *testing.T) {
+	tests := []struct {
+		name  string
+		title string
+		want  string
+	}{
+		{"no marker", "Add a feature", "Add a feature"},
+		{"draft colon", "Draft: Add a feature", "Add a feature"},
+		{"lowercase", "draft: Add a feature", "Add a feature"},
+		{"uppercase", "DRAFT: Add a feature", "Add a feature"},
+		{"bracketed", "[Draft] Add a feature", "Add a feature"},
+		{"parenthesised", "(Draft) Add a feature", "Add a feature"},
+		{"wip colon", "WIP: Add a feature", "Add a feature"},
+		{"wip bracketed", "[WIP] Add a feature", "Add a feature"},
+		{"only the leading marker goes", "Draft: Draft: x", "Draft: x"},
+		{"marker inside the title stays", "Add the Draft: banner", "Add the Draft: banner"},
+		{"leading space", "  Draft: x", "x"},
+		{"marker only", "Draft:", ""},
+		{"empty", "", ""},
+		// "Drafting" starts with "draft" but is not a marker.
+		{"word starting with draft", "Drafting the release", "Drafting the release"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripDraftMarker(tt.title); got != tt.want {
+				t.Errorf("stripDraftMarker(%q) = %q, want %q", tt.title, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMRTitleDraftReady covers issue #76: --draft and --ready set the state
+// GitLab derives from the title, without the caller having to know the prefix
+// convention, and --ready overrides the "Draft" default of --commit-prefix.
+func TestMRTitleDraftReady(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     *Config
+		existingMR *MergeRequest
+		want       string
+	}{
+		{
+			name:   "default is unchanged",
+			config: &Config{CommitPrefix: "Draft", SourceBranch: "feature/x"},
+			want:   "Draft: feature/x",
+		},
+		{
+			name:   "draft with the default prefix does not double the marker",
+			config: &Config{CommitPrefix: "Draft", SourceBranch: "feature/x", Draft: true},
+			want:   "Draft: feature/x",
+		},
+		{
+			name:   "draft keeps a non-draft prefix and leads with the marker",
+			config: &Config{CommitPrefix: "Feature", SourceBranch: "feature/x", Draft: true},
+			want:   "Draft: Feature: feature/x",
+		},
+		{
+			name:   "draft with a custom title",
+			config: &Config{CommitPrefix: "", Title: "Add a feature", Draft: true},
+			want:   "Draft: Add a feature",
+		},
+		{
+			name:   "ready drops the Draft default of --commit-prefix",
+			config: &Config{CommitPrefix: "Draft", SourceBranch: "feature/x", Ready: true},
+			want:   "feature/x",
+		},
+		{
+			name:   "ready keeps a non-draft prefix",
+			config: &Config{CommitPrefix: "Feature", SourceBranch: "feature/x", Ready: true},
+			want:   "Feature: feature/x",
+		},
+		{
+			name:       "ready strips the marker from the existing MR title",
+			config:     &Config{CommitPrefix: "Draft", SourceBranch: "feature/x", Ready: true},
+			existingMR: &MergeRequest{Title: "Draft: Something a human wrote"},
+			want:       "Something a human wrote",
+		},
+		{
+			name:       "ready leaves an already-ready existing title alone",
+			config:     &Config{CommitPrefix: "Draft", SourceBranch: "feature/x", Ready: true},
+			existingMR: &MergeRequest{Title: "Something a human wrote"},
+			want:       "Something a human wrote",
+		},
+		{
+			name:       "an explicit --title beats the existing MR title",
+			config:     &Config{CommitPrefix: "", Title: "Renamed", Ready: true},
+			existingMR: &MergeRequest{Title: "Draft: Something a human wrote"},
+			want:       "Renamed",
+		},
+		{
+			name:       "without --ready the existing title is not consulted",
+			config:     &Config{CommitPrefix: "Draft", SourceBranch: "feature/x"},
+			existingMR: &MergeRequest{Title: "Something a human wrote"},
+			want:       "Draft: feature/x",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mrTitle(tt.config, tt.existingMR); got != tt.want {
+				t.Errorf("mrTitle() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRunReadyUpdatesTitle drives --ready through run(): the PUT must carry the
+// existing title with its marker removed, which is what actually flips GitLab's
+// derived draft flag.
+func TestRunReadyUpdatesTitle(t *testing.T) {
+	var sentTitle string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v4/projects/123" && r.Method == http.MethodGet:
+			if err := json.NewEncoder(w).Encode(Project{ID: 123, DefaultBranch: "main"}); err != nil {
+				t.Errorf("encode project: %v", err)
+			}
+		case r.URL.Path == "/api/v4/projects/123/merge_requests" && r.Method == http.MethodGet:
+			if _, err := w.Write([]byte(`[{"id":1,"iid":42,"title":"Draft: Human written title"}]`)); err != nil {
+				t.Errorf("write MR list: %v", err)
+			}
+		case r.URL.Path == "/api/v4/projects/123/merge_requests/42" && r.Method == http.MethodPut:
+			var sent MRUpdateRequest
+			if err := json.NewDecoder(r.Body).Decode(&sent); err != nil {
+				t.Errorf("decode update request: %v", err)
+			}
+			sentTitle = sent.Title
+			if _, err := w.Write([]byte(`{"id":1,"iid":42}`)); err != nil {
+				t.Errorf("write update response: %v", err)
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	config := &Config{
+		PrivateToken: "test-token",
+		SourceBranch: "feature/test",
+		ProjectID:    123,
+		GitLabURL:    server.URL,
+		UserIDs:      []int{1},
+		TargetBranch: "main",
+		CommitPrefix: "Draft",
+		UpdateMR:     true,
+		Ready:        true,
+	}
+
+	if err := run(context.Background(), config); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+
+	if sentTitle != "Human written title" {
+		t.Errorf("title sent = %q, want %q", sentTitle, "Human written title")
+	}
+}
+
+// TestDraftReadyValidation pins the flag combinations that are refused rather
+// than silently resolved one way.
+func TestDraftReadyValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    *Config
+		errSubstr string
+	}{
+		{
+			name:      "draft with ready",
+			config:    &Config{Draft: true, Ready: true},
+			errSubstr: "--draft cannot be used with --ready",
+		},
+		{
+			name:      "draft with auto-merge",
+			config:    &Config{Draft: true, AutoMerge: true},
+			errSubstr: "--auto-merge cannot be used with --draft",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateConfig(tt.config)
+			if err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.errSubstr) {
+				t.Errorf("error = %v, want it to contain %q", err, tt.errSubstr)
+			}
+		})
+	}
+}
+
+// TestReadyAllowsAutoMerge is the counterpart: --ready is what makes the default
+// "Draft" commit prefix compatible with --auto-merge.
+func TestReadyAllowsAutoMerge(t *testing.T) {
+	config := &Config{AutoMerge: true, CommitPrefix: "Draft", Ready: true}
+	if err := validateConfig(config); err != nil {
+		t.Errorf("validateConfig() error = %v, want nil", err)
+	}
+}
+
 // resetFlagSet replaces the package-level flag.CommandLine with a fresh FlagSet
 // using ContinueOnError. parseFlags re-registers every flag on flag.CommandLine,
 // so without a reset the second subtest would panic with "flag redefined".


### PR DESCRIPTION
Closes #76.

## The issue's premise does not hold

The issue proposes sending `"draft": true` on the API instead of manipulating the title. There is no such parameter: the Merge Requests API accepts `title`, `description`, `labels`, `milestone_id`, `squash`, `state_event` and so on, but **no `draft`** — and the `draft` field in responses is *derived from the title*. GitLab's own documented way to set the state is the title prefix (`Draft:`, `[Draft]`, `(Draft)`); the UI's "Mark as ready" and the `/ready` quick action both come down to rewriting the title.

So the flags do go through the title. What changes is that the caller no longer has to know the convention, and — the part the issue actually needed — **taking an MR out of draft is now possible at all**, which it was not before.

## Behaviour

```bash
gitlab-auto-mr --draft               # open (or keep) the MR as a draft
gitlab-auto-mr --ready --update-mr   # take an existing MR out of draft
```

- `--draft` puts `Draft: ` at the front, without doubling a marker that is already there. A non-draft `--commit-prefix` is kept after it: `--draft --commit-prefix Feature` → `Draft: Feature: my-branch`.
- `--ready` strips a leading marker in any accepted spelling (`Draft:`, `[Draft]`, `(Draft)`, and the `WIP` forms, case-insensitively) **and** overrides the `Draft` default of `--commit-prefix`, which would otherwise put the marker straight back.

**The decision worth reviewing:** on an existing MR, `--ready` strips the marker from the *MR's own* title instead of rebuilding it from the branch name. Without that, `--ready --update-mr` would take `Draft: Fix the retry backoff` and rename it to `feature/retry-fix` — marking a draft ready should not silently discard a title someone wrote by hand. `--title` still renames deliberately, and this only applies when `--ready` is set, so no existing behaviour changes.

`--draft` + `--ready` are refused together; `--draft` + `--auto-merge` is refused for the reason a `Draft` commit prefix already was. `--ready` is what makes the default prefix compatible with `--auto-merge`.

`--commit-prefix` is **not** deprecated — the issue floated that, but it still does something these flags do not (arbitrary prefixes), and deprecating the default path of every existing user to gain nothing seemed the wrong trade.

## Tests

- `TestStripDraftMarker` — 14 cases: every accepted spelling, case-insensitivity, only the *leading* marker removed, a marker mid-title left alone, and `Drafting the release` not mistaken for a marker.
- `TestMRTitleDraftReady` — 10 cases over `mrTitle`: the default path unchanged, no doubled marker, custom prefix kept after the marker, `--ready` dropping the `Draft` default, the existing-title behaviour above, an explicit `--title` winning, and the existing title *not* consulted without `--ready`.
- `TestRunReadyUpdatesTitle` — through `run()`, asserting the `PUT` carries `Human written title` when the MR was `Draft: Human written title`.
- `TestDraftReadyValidation`, `TestReadyAllowsAutoMerge`.

```
$ go test -race ./...
ok  	gitlab-auto-mr	3.007s
$ golangci-lint run
0 issues.
$ go test -cover ./...
coverage: 90.4% of statements
```

Sources: [Merge requests API](https://docs.gitlab.com/api/merge_requests/), [Draft merge requests](https://docs.gitlab.com/user/project/merge_requests/drafts/)
